### PR TITLE
Fix isset for relationships

### DIFF
--- a/lib/Model.php
+++ b/lib/Model.php
@@ -360,7 +360,27 @@ class Model
      */
     public function __isset($attribute_name)
     {
-        return array_key_exists($attribute_name, $this->attributes) || array_key_exists($attribute_name, static::$alias_attribute);
+        // check for aliased attribute
+        if (array_key_exists($attribute_name, static::$alias_attribute)) {
+            return true;
+        }
+
+        // check for attribute
+        if (array_key_exists($attribute_name, $this->attributes)) {
+            return true;
+        }
+
+        // check for getters
+        if (method_exists($this, "get_${attribute_name}")) {
+            return true;
+        }
+
+        // check for relationships
+        if (static::table()->has_relationship($attribute_name)) {
+            return true;
+        }
+
+        return false;
     }
 
     /**

--- a/test/ActiveRecordTest.php
+++ b/test/ActiveRecordTest.php
@@ -298,6 +298,9 @@ class ActiveRecordTest extends DatabaseTest
         $book = new Book();
         $this->assert_true(isset($book->name));
         $this->assert_false(isset($book->sharks));
+
+        $author = Author::find(1);
+        $this->assert_true(isset($author->awesome_person));
     }
 
     public function test_readonly_only_halt_on_write_method()

--- a/test/RelationshipTest.php
+++ b/test/RelationshipTest.php
@@ -589,7 +589,6 @@ class RelationshipTest extends DatabaseTest
 
         foreach ($assocs as $assoc) {
             $this->assert_internal_type('array', $authors[1]->$assoc);
-            $this->assert_true(empty($authors[1]->$assoc));
         }
 
         $this->assert_sql_has('WHERE author_id IN(?,?)', ActiveRecord\Table::load('Author')->last_sql);


### PR DESCRIPTION
### Description
Fix for https://github.com/php-activerecord/activerecord/issues/8

See also:
https://github.com/jpfuentes2/php-activerecord/issues/156
http://www.phpactiverecord.org/boards/4/topics/1678-php-ar-and-twig

The issue is that the `__isset` magic method in `Model` only checks its own `$attributes` and `$alias_attributes` properties and doesn't consider other possibilities, such as magic getters and relationships. I'm using a fix proposed by @dfyx that handles these use cases. Thanks, @dfyx!

### Changes

* added checks to `__isset` for getters and relationships
* expanded existing `test_isset` test to check a relationship 
* removed an assert from `RelationShipTest::test_eager_loading_has_many_array_of_includes`. It was no longer passing with the fix for `__isset`, and it didn't seem to provide any value as the check it was doing would always pass, regardless of whether you were eager loading or not. I verified that, and also that the expanded `__isset` does not cause any unintended database queries.

### Reviewers
@dfyx @hising @erayd