### PR TITLE
fix types, fix array return

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ before_script:
   - psql -c 'CREATE DATABASE phpar_test;' -U postgres
 
 services:
-  - memcache
+  - memcached
 
 env:
   - PHPAR_MYSQL=mysql://root@127.0.0.1/phpar_test PHPAR_PGSQL=pgsql://postgres@127.0.0.1/phpar_test

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ install:
   - travis_retry composer install --prefer-dist --no-interaction
 
 before_script:
-  - echo 'extension = "memcache.so"' >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
+  - echo 'extension = "memcached.so"' >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
   - mysql -e 'CREATE DATABASE phpar_test;'
   - psql -c 'CREATE DATABASE phpar_test;' -U postgres
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ matrix:
     - php: 5.6
     - php: 7.0
       env:
-      - PHPAR_MYSQL=mysql://root@127.0.0.1/phpar_test PHPAR_PGSQL=pgsql://postgres@127.0.0.1/phpar_test WITH_PHPCSFIXER=true WITH_DOCS=true
+      - PHPAR_MYSQL=mysql://root@127.0.0.1/phpar_test PHPAR_PGSQL=pgsql://postgres@127.0.0.1/phpar_test WITH_DOCS=true
     - php: 7.1
     - php: 'nightly'
   allow_failures:

--- a/examples/orders/models/Order.php
+++ b/examples/orders/models/Order.php
@@ -25,9 +25,9 @@ class Order extends ActiveRecord\Model
 
     public function apply_tax()
     {
-        if ($this->person->state == 'VA') {
+        if ('VA' == $this->person->state) {
             $tax = 0.045;
-        } elseif ($this->person->state == 'CA') {
+        } elseif ('CA' == $this->person->state) {
             $tax = 0.10;
         } else {
             $tax = 0.02;

--- a/lib/CallBack.php
+++ b/lib/CallBack.php
@@ -180,7 +180,7 @@ class CallBack
         $first = substr($name, 0, 6);
 
         // starts with /(after|before)_(create|update)/
-        if (($first == 'after_' || $first == 'before') && (($second = substr($name, 7, 5)) == 'creat' || $second == 'updat' || $second == 'reate' || $second == 'pdate')) {
+        if (('after_' == $first || 'before' == $first) && ('creat' == ($second = substr($name, 7, 5)) || 'updat' == $second || 'reate' == $second || 'pdate' == $second)) {
             $temporal_save = str_replace(['create', 'update'], 'save', $name);
 
             if (!isset($this->registry[$temporal_save])) {
@@ -194,7 +194,7 @@ class CallBack
             foreach ($registry as $method) {
                 $ret = ($method instanceof Closure ? $method($model) : $model->$method());
 
-                if (false === $ret && $first === 'before') {
+                if (false === $ret && 'before' === $first) {
                     return false;
                 }
             }
@@ -240,8 +240,8 @@ class CallBack
                         'Please change the visibility of ' . $this->klass->getName() . '->' . $closure_or_method_name . '()');
                 }
 
-                    // i'm a dirty ruby programmer
-                    throw new ActiveRecordException("Unknown method for callback: $name" .
+                // i'm a dirty ruby programmer
+                throw new ActiveRecordException("Unknown method for callback: $name" .
                         (is_string($closure_or_method_name) ? ": #$closure_or_method_name" : ''));
             }
         }

--- a/lib/Column.php
+++ b/lib/Column.php
@@ -171,7 +171,7 @@ class Column
      */
     public function cast($value, $connection)
     {
-        if ($value === null) {
+        if (null === $value) {
             return null;
         }
 
@@ -212,7 +212,7 @@ class Column
      */
     public function map_raw_type()
     {
-        if ($this->raw_type == 'integer') {
+        if ('integer' == $this->raw_type) {
             $this->raw_type = 'int';
         }
 

--- a/lib/Connection.php
+++ b/lib/Connection.php
@@ -112,7 +112,7 @@ abstract class Connection
     {
         $config = Config::instance();
 
-        if (strpos($connection_string_or_connection_name, '://') === false) {
+        if (false === strpos($connection_string_or_connection_name, '://')) {
             $connection_string = $connection_string_or_connection_name ?
                 $config->get_connection($connection_string_or_connection_name) :
                 $config->get_default_connection_string();
@@ -200,9 +200,9 @@ abstract class Connection
         $info->user = isset($url['user']) ? $url['user'] : null;
         $info->pass = isset($url['pass']) ? $url['pass'] : null;
 
-        $allow_blank_db = ($info->protocol == 'sqlite');
+        $allow_blank_db = ('sqlite' == $info->protocol);
 
-        if ($info->host == 'unix(') {
+        if ('unix(' == $info->host) {
             $socket_database = $info->host . '/' . $info->db;
 
             if ($allow_blank_db) {
@@ -215,7 +215,7 @@ abstract class Connection
                 $info->host = $matches[1][0];
                 $info->db = $matches[2][0];
             }
-        } elseif (substr($info->host, 0, 8) == 'windows(') {
+        } elseif ('windows(' == substr($info->host, 0, 8)) {
             $info->host = urldecode(substr($info->host, 8) . '/' . substr($info->db, 0, -1));
             $info->db = null;
         }
@@ -228,7 +228,7 @@ abstract class Connection
             $info->port = $url['port'];
         }
 
-        if (strpos($connection_url, 'decode=true') !== false) {
+        if (false !== strpos($connection_url, 'decode=true')) {
             if ($info->user) {
                 $info->user = urldecode($info->user);
             }
@@ -242,7 +242,7 @@ abstract class Connection
             foreach (explode('/&/', $url['query']) as $pair) {
                 list($name, $value) = explode('=', $pair);
 
-                if ($name == 'charset') {
+                if ('charset' == $name) {
                     $info->charset = $value;
                 }
             }
@@ -262,7 +262,7 @@ abstract class Connection
     {
         try {
             // unix sockets start with a /
-            if ($info->host[0] != '/') {
+            if ('/' != $info->host[0]) {
                 $host = "host=$info->host";
 
                 if (isset($info->port)) {

--- a/lib/Expressions.php
+++ b/lib/Expressions.php
@@ -33,7 +33,7 @@ class Expressions
             list($expressions, $values) = $this->build_sql_from_hash($expressions, $glue);
         }
 
-        if ($expressions != '') {
+        if ('' != $expressions) {
             if (!$values) {
                 $values = array_slice(func_get_args(), 2);
             }
@@ -104,14 +104,14 @@ class Expressions
         for ($i=0, $n=strlen($this->expressions), $j=0; $i<$n; ++$i) {
             $ch = $this->expressions[$i];
 
-            if ($ch == self::ParameterMarker) {
-                if ($quotes % 2 == 0) {
+            if (self::ParameterMarker == $ch) {
+                if (0 == $quotes % 2) {
                     if ($j > $num_values-1) {
                         throw new ExpressionsException("No bound parameter for index $j");
                     }
                     $ch = $this->substitute($values, $substitute, $i, $j++);
                 }
-            } elseif ($ch == '\'' && $i > 0 && $this->expressions[$i-1] != '\\') {
+            } elseif ('\'' == $ch && $i > 0 && '\\' != $this->expressions[$i-1]) {
                 ++$quotes;
             }
 
@@ -151,7 +151,7 @@ class Expressions
         if (is_array($value)) {
             $value_count = count($value);
 
-            if ($value_count === 0) {
+            if (0 === $value_count) {
                 if ($substitute) {
                     return 'NULL';
                 }

--- a/lib/Inflector.php
+++ b/lib/Inflector.php
@@ -35,7 +35,7 @@ abstract class Inflector
         $camelized = '';
 
         for ($i=0, $n=strlen($s); $i<$n; ++$i) {
-            if ($s[$i] == '_' && $i+1 < $n) {
+            if ('_' == $s[$i] && $i+1 < $n) {
                 $camelized .= strtoupper($s[++$i]);
             } else {
                 $camelized .= $s[$i];

--- a/lib/Model.php
+++ b/lib/Model.php
@@ -1724,10 +1724,10 @@ class Model
         //find by pk
         elseif (1 === count($args) && 1 == $num_args) {
             $args = $args[0];
+        }
 
-            if(is_array($args) && array_values($args)==$args) {
-                $single = false;
-            }
+        if(is_array($args) && array_values($args)==$args) {
+            $single = false;
         }
 
         // anything left in $args is a find by pk

--- a/lib/Model.php
+++ b/lib/Model.php
@@ -1727,11 +1727,12 @@ class Model
 
         // anything left in $args is a find by pk
         if ($num_args > 0 && !isset($options['conditions'])) {
-            return static::find_by_pk($args, $options);
+            $list = static::find_by_pk($args, $options, true);
         }
-
-        $options['mapped_names'] = static::$alias_attribute;
-        $list = static::table()->find($options);
+        else {
+			$options['mapped_names'] = static::$alias_attribute;
+			$list = static::table()->find($options);
+		}
 
         return $single ? (!empty($list) ? $list[0] : null) : $list;
     }
@@ -1772,9 +1773,9 @@ class Model
      *
      * @return static|static[]
      */
-    public static function find_by_pk($values, $options)
+    public static function find_by_pk($values, $options, $forceArray = false)
     {
-        $single = !is_array($values);
+        $single = !is_array($values) && !$forceArray;
         if ($values===null) {
             throw new RecordNotFound("Couldn't find " . get_called_class() . ' without an ID');
         }

--- a/lib/Model.php
+++ b/lib/Model.php
@@ -1610,7 +1610,7 @@ class Model
      *
      * @see find
      *
-     * @return Model|null The first matched record or null if not found
+     * @return static|null The first matched record or null if not found
      */
     public static function first(/* ... */)
     {
@@ -1679,7 +1679,7 @@ class Model
      *
      * @throws {@link RecordNotFound} if no options are passed or finding by pk and no records matched
      *
-     * @return mixed An array of records found if doing a find_all otherwise a
+     * @return static|static[]|null An array of records found if doing a find_all otherwise a
      *               single Model object or null if it wasn't found. NULL is only return when
      *               doing a first/last find. If doing an all find and no records matched this
      *               will return an empty array.
@@ -1770,10 +1770,11 @@ class Model
      *
      * @throws {@link RecordNotFound} if a record could not be found
      *
-     * @return Model
+     * @return static|static[]
      */
     public static function find_by_pk($values, $options)
     {
+    	$single = !is_array($values);
         if ($values===null) {
             throw new RecordNotFound("Couldn't find " . get_called_class() . ' without an ID');
         }
@@ -1802,7 +1803,7 @@ class Model
             throw new RecordNotFound("Couldn't find all $class with IDs ($values) (found $results, but was looking for $expected)");
         }
 
-        return $expected == 1 ? $list[0] : $list;
+        return $single ? $list[0] : $list;
     }
 
     /**
@@ -1816,7 +1817,7 @@ class Model
      * @param string $sql    The raw SELECT query
      * @param array  $values An array of values for any parameters that needs to be bound
      *
-     * @return array An array of models
+     * @return static[] An array of models
      */
     public static function find_by_sql($sql, $values=null)
     {

--- a/lib/Model.php
+++ b/lib/Model.php
@@ -1720,9 +1720,14 @@ class Model
             $args = array_slice($args, 1);
             $num_args--;
         }
+
         //find by pk
         elseif (1 === count($args) && 1 == $num_args) {
             $args = $args[0];
+
+            if(is_array($args) && array_values($args)==$args) {
+                $single = false;
+            }
         }
 
         // anything left in $args is a find by pk
@@ -1730,9 +1735,9 @@ class Model
             $list = static::find_by_pk($args, $options, true);
         }
         else {
-			$options['mapped_names'] = static::$alias_attribute;
-			$list = static::table()->find($options);
-		}
+            $options['mapped_names'] = static::$alias_attribute;
+            $list = static::table()->find($options);
+        }
 
         return $single ? (!empty($list) ? $list[0] : null) : $list;
     }

--- a/lib/Model.php
+++ b/lib/Model.php
@@ -450,7 +450,7 @@ class Model
             return $this->assign_attribute($name, $value);
         }
 
-        if ($name == 'id') {
+        if ('id' == $name) {
             return $this->assign_attribute($this->get_primary_key(true), $value);
         }
 
@@ -555,7 +555,7 @@ class Model
             return $this->__relationships[$name];
         }
 
-        if ($name == 'id') {
+        if ('id' == $name) {
             $pk = $this->get_primary_key(true);
             if (isset($this->attributes[$pk])) {
                 return $this->attributes[$pk];
@@ -735,7 +735,7 @@ class Model
      */
     private function is_delegated($name, &$delegate)
     {
-        if ($delegate['prefix'] != '') {
+        if ('' != $delegate['prefix']) {
             $name = substr($name, strlen($delegate['prefix'])+1);
         }
 
@@ -908,12 +908,11 @@ class Model
         // if we've got an autoincrementing/sequenced pk set it
         // don't need this check until the day comes that we decide to support composite pks
         // if (count($pk) == 1)
-        {
-            $column = $table->get_column_by_inflected_name($pk);
 
-            if ($column->auto_increment || $use_sequence) {
-                $this->attributes[$pk] = $column->cast(static::connection()->insert_id($table->sequence), static::connection());
-            }
+        $column = $table->get_column_by_inflected_name($pk);
+
+        if ($column->auto_increment || $use_sequence) {
+            $this->attributes[$pk] = $column->cast(static::connection()->insert_id($table->sequence), static::connection());
         }
 
         $this->__new_record = false;
@@ -1340,7 +1339,7 @@ class Model
                 }
             } else {
                 // ignore OciAdapter's limit() stuff
-                if ($name == 'ar_rnum__') {
+                if ('ar_rnum__' == $name) {
                     continue;
                 }
 
@@ -1477,18 +1476,18 @@ class Model
         $options = static::extract_and_validate_options($args);
         $create = false;
 
-        if (substr($method, 0, 17) == 'find_or_create_by') {
+        if ('find_or_create_by' == substr($method, 0, 17)) {
             $attributes = substr($method, 17);
 
             // can't take any finders with OR in it when doing a find_or_create_by
-            if (strpos($attributes, '_or_') !== false) {
+            if (false !== strpos($attributes, '_or_')) {
                 throw new ActiveRecordException("Cannot use OR'd attributes in find_or_create_by");
             }
             $create = true;
             $method = 'find_by' . substr($method, 17);
         }
 
-        if (substr($method, 0, 7) === 'find_by') {
+        if ('find_by' === substr($method, 0, 7)) {
             $attributes = substr($method, 8);
             $options['conditions'] = SQLBuilder::create_conditions_from_underscored_string(static::connection(), $attributes, $args, static::$alias_attribute);
 
@@ -1497,11 +1496,11 @@ class Model
             }
 
             return $ret;
-        } elseif (substr($method, 0, 11) === 'find_all_by') {
+        } elseif ('find_all_by' === substr($method, 0, 11)) {
             $options['conditions'] = SQLBuilder::create_conditions_from_underscored_string(static::connection(), substr($method, 12), $args, static::$alias_attribute);
 
             return static::find('all', $options);
-        } elseif (substr($method, 0, 8) === 'count_by') {
+        } elseif ('count_by' === substr($method, 0, 8)) {
             $options['conditions'] = SQLBuilder::create_conditions_from_underscored_string(static::connection(), substr($method, 9), $args, static::$alias_attribute);
 
             return static::count($options);
@@ -1680,21 +1679,20 @@ class Model
      * @throws {@link RecordNotFound} if no options are passed or finding by pk and no records matched
      *
      * @return static|static[]|null
-	 *
-	 * The rules for what gets returned are complex, but predictable:
-	 *
-	 * /-------------------------------------------------------------------------------------------
-	 * 	First Argument								Return Type			Example
-	 * --------------------------------------------------------------------------------------------
-	 *	int|string									static				User::find(3);
-	 * 	array<string, int|string>					static				User::find(["name"=>"Philip"]);
-	 * 	"first"										static|null			User::find("first", ["name"=>"Waldo"]);
-	 * 	"last"										static|null			User::find("last", ["name"=>"William"]);
-	 *  "all"										static[]			User::find("all", ["name" => "Stephen"]
-	 *  ...int|string								static[]			User::find(1, 3, 5, 8);
-	 *  array<int,int|string>						static[]			User::find([1,3,5,8]);
-	 * 	array<"conditions", array<string,string>>	static[]			User::find(["conditions"=> ["name" => "Kurt"]]);
      *
+     * The rules for what gets returned are complex, but predictable:
+     *
+     * /-------------------------------------------------------------------------------------------
+     * 	First Argument								Return Type			Example
+     * --------------------------------------------------------------------------------------------
+     *	int|string									static				User::find(3);
+     * 	array<string, int|string>					static				User::find(["name"=>"Philip"]);
+     * 	"first"										static|null			User::find("first", ["name"=>"Waldo"]);
+     * 	"last"										static|null			User::find("last", ["name"=>"William"]);
+     *  "all"										static[]			User::find("all", ["name" => "Stephen"]
+     *  ...int|string								static[]			User::find(1, 3, 5, 8);
+     *  array<int,int|string>						static[]			User::find([1,3,5,8]);
+     * 	array<"conditions", array<string,string>>	static[]			User::find(["conditions"=> ["name" => "Kurt"]]);
      */
     public static function find(/* $type, $options */)
     {
@@ -1709,7 +1707,7 @@ class Model
         $num_args = count($args);
         $single = true;
 
-        if ($num_args > 0 && ($args[0] === 'all' || $args[0] === 'first' || $args[0] === 'last')) {
+        if ($num_args > 0 && ('all' === $args[0] || 'first' === $args[0] || 'last' === $args[0])) {
             switch ($args[0]) {
                 case 'all':
                     $single = false;
@@ -1724,6 +1722,7 @@ class Model
 
                 // fall thru
 
+                // no break
                 case 'first':
                     $options['limit'] = 1;
                     $options['offset'] = 0;
@@ -1731,27 +1730,24 @@ class Model
             }
 
             $args = array_slice($args, 1);
-            $num_args--;
+            --$num_args;
         }
 
         //find by pk
-        else
-        {
+        else {
             if (1 === count($args) && 1 == $num_args) {
                 $args = $args[0];
             }
 
-            if(is_array($args) && array_values($args)==$args) {
+            if (is_array($args) && array_values($args)==$args) {
                 $single = false;
             }
         }
 
-
         // anything left in $args is a find by pk
         if ($num_args > 0 && !isset($options['conditions'])) {
             $list = static::find_by_pk($args, $options, true);
-        }
-        else {
+        } else {
             $options['mapped_names'] = static::$alias_attribute;
             $list = static::table()->find($options);
         }
@@ -1798,7 +1794,7 @@ class Model
     public static function find_by_pk($values, $options, $forceArray = false)
     {
         $single = !is_array($values) && !$forceArray;
-        if ($values===null) {
+        if (null===$values) {
             throw new RecordNotFound("Couldn't find " . get_called_class() . ' without an ID');
         }
 
@@ -1819,7 +1815,7 @@ class Model
                 $values = join(',', $values);
             }
 
-            if ($expected == 1) {
+            if (1 == $expected) {
                 throw new RecordNotFound("Couldn't find $class with ID=$values");
             }
 
@@ -2040,8 +2036,9 @@ class Model
      * @param string $method_name name of the call back to run
      * @param bool   $must_exist  set to true to raise an exception if the callback does not exist
      *
-     * @return bool True if invoked or null if not
      * @throws ActiveRecordException
+     *
+     * @return bool True if invoked or null if not
      */
     private function invoke_callback($method_name, $must_exist=true)
     {
@@ -2087,7 +2084,7 @@ class Model
         try {
             $connection->transaction();
 
-            if ($closure() === false) {
+            if (false === $closure()) {
                 $connection->rollback();
 
                 return false;

--- a/lib/Model.php
+++ b/lib/Model.php
@@ -1728,7 +1728,7 @@ class Model
                 $args = $args[0];
             }
 
-            if(is_array($args) && array_values($args)==$args) {
+            if(is_array($args) && array_values($args)==$args && count($args)) {
                 $single = false;
             }
         }

--- a/lib/Model.php
+++ b/lib/Model.php
@@ -829,7 +829,7 @@ class Model
      * @param bool  $validate         True if the validators should be run
      * @param bool  $guard_attributes Set to true to guard protected/non-accessible attributes
      *
-     * @return Model
+     * @return static
      */
     public static function create($attributes, $validate=true, $guard_attributes=true)
     {
@@ -1548,7 +1548,7 @@ class Model
      *
      * @see find
      *
-     * @return array array of records found
+     * @return static[]
      */
     public static function all(/* ... */)
     {
@@ -1680,15 +1680,21 @@ class Model
      * @throws {@link RecordNotFound} if no options are passed or finding by pk and no records matched
      *
      * @return static|static[]|null
-     * 	Returns an array of records if:
-     * 		- doing a "all"
-     * 		- passing in an array of ids.
-     * 		- an associative array is passed in
+	 *
+	 * The rules for what gets returned are complex, but predictable:
+	 *
+	 * /-------------------------------------------------------------------------------------------
+	 * 	First Argument								Return Type			Example
+	 * --------------------------------------------------------------------------------------------
+	 *	int|string									static				User::find(3);
+	 * 	array<string, int|string>					static				User::find(["name"=>"Philip"]);
+	 * 	"first"										static|null			User::find("first", ["name"=>"Waldo"]);
+	 * 	"last"										static|null			User::find("last", ["name"=>"William"]);
+	 *  "all"										static[]			User::find("all", ["name" => "Stephen"]
+	 *  ...int|string								static[]			User::find(1, 3, 5, 8);
+	 *  array<int,int|string>						static[]			User::find([1,3,5,8]);
+	 * 	array<"conditions", array<string,string>>	static[]			User::find(["conditions"=> ["name" => "Kurt"]]);
      *
-     * Returns NULL if:
-     * 		- doing a "first" or "last" query, and none are found
-     *
-     * Otherwise returns a single Model object.
      */
     public static function find(/* $type, $options */)
     {

--- a/lib/Model.php
+++ b/lib/Model.php
@@ -1774,7 +1774,7 @@ class Model
      */
     public static function find_by_pk($values, $options)
     {
-    	$single = !is_array($values);
+        $single = !is_array($values);
         if ($values===null) {
             throw new RecordNotFound("Couldn't find " . get_called_class() . ' without an ID');
         }

--- a/lib/Model.php
+++ b/lib/Model.php
@@ -1394,7 +1394,7 @@ class Model
         $this->__relationships = [];
         $pk = array_values($this->get_values_for($this->get_primary_key()));
 
-        $this->set_attributes_via_mass_assignment($this->find($pk)->attributes, false);
+        $this->set_attributes_via_mass_assignment($this->find($pk[0])->attributes, false);
         $this->reset_dirty();
 
         return $this;

--- a/lib/Model.php
+++ b/lib/Model.php
@@ -1722,13 +1722,17 @@ class Model
         }
 
         //find by pk
-        elseif (1 === count($args) && 1 == $num_args) {
-            $args = $args[0];
+        else
+        {
+            if (1 === count($args) && 1 == $num_args) {
+                $args = $args[0];
+            }
+
+            if(is_array($args) && array_values($args)==$args) {
+                $single = false;
+            }
         }
 
-        if(is_array($args) && array_values($args)==$args) {
-            $single = false;
-        }
 
         // anything left in $args is a find by pk
         if ($num_args > 0 && !isset($options['conditions'])) {

--- a/lib/Model.php
+++ b/lib/Model.php
@@ -1679,10 +1679,17 @@ class Model
      *
      * @throws {@link RecordNotFound} if no options are passed or finding by pk and no records matched
      *
-     * @return static|static[]|null An array of records found if doing a find_all otherwise a
-     *               single Model object or null if it wasn't found. NULL is only return when
-     *               doing a first/last find. If doing an all find and no records matched this
-     *               will return an empty array.
+     * @return static|static[]|null
+     * 	Returns an array of records if:
+     * 		- doing a "all"
+     * 		- passing in an array of ids.
+     *		- "conditions" are passed in.
+     * 		- an associative array is passed in
+     *
+     * Returns NULL if:
+     * 		- doing a "first" or "last" query, and none are found
+     *
+     * Otherwise returns a single Model object.
      */
     public static function find(/* $type, $options */)
     {
@@ -1693,6 +1700,10 @@ class Model
         }
         $args = func_get_args();
         $options = static::extract_and_validate_options($args);
+
+        if(isset($options['conditions']) && (!count($args) || $args['0'] != "all")) {
+            array_unshift($args, "all");
+        }
         $num_args = count($args);
         $single = true;
 
@@ -1728,7 +1739,7 @@ class Model
                 $args = $args[0];
             }
 
-            if(is_array($args) && array_values($args)==$args && count($args)) {
+            if(is_array($args) && array_values($args)==$args) {
                 $single = false;
             }
         }

--- a/lib/Model.php
+++ b/lib/Model.php
@@ -1683,7 +1683,6 @@ class Model
      * 	Returns an array of records if:
      * 		- doing a "all"
      * 		- passing in an array of ids.
-     *		- "conditions" are passed in.
      * 		- an associative array is passed in
      *
      * Returns NULL if:
@@ -1701,9 +1700,6 @@ class Model
         $args = func_get_args();
         $options = static::extract_and_validate_options($args);
 
-        if(isset($options['conditions']) && (!count($args) || $args['0'] != "all")) {
-            array_unshift($args, "all");
-        }
         $num_args = count($args);
         $single = true;
 

--- a/lib/Relationship.php
+++ b/lib/Relationship.php
@@ -84,7 +84,7 @@ abstract class AbstractRelationship implements InterfaceRelationship
 
         $relationship = strtolower(denamespace(get_called_class()));
 
-        if ($relationship === 'hasmany' || $relationship === 'hasandbelongstomany') {
+        if ('hasmany' === $relationship || 'hasandbelongstomany' === $relationship) {
             $this->poly_relationship = true;
         }
 
@@ -722,7 +722,7 @@ class BelongsTo extends AbstractRelationship
 
     public function __get($name)
     {
-        if ($name === 'primary_key' && !isset($this->primary_key)) {
+        if ('primary_key' === $name && !isset($this->primary_key)) {
             $this->primary_key = [Table::load($this->class_name)->pk[0]];
         }
 

--- a/lib/SQLBuilder.php
+++ b/lib/SQLBuilder.php
@@ -209,9 +209,9 @@ class SQLBuilder
         for ($i=0, $n=count($parts); $i<$n; ++$i) {
             $v = strtolower($parts[$i]);
 
-            if (strpos($v, ' asc') !== false) {
+            if (false !== strpos($v, ' asc')) {
                 $parts[$i] = preg_replace('/asc/i', 'DESC', $parts[$i]);
-            } elseif (strpos($v, ' desc') !== false) {
+            } elseif (false !== strpos($v, ' desc')) {
                 $parts[$i] = preg_replace('/desc/i', 'ASC', $parts[$i]);
             } else {
                 $parts[$i] .= ' DESC';
@@ -316,7 +316,7 @@ class SQLBuilder
         require_once 'Expressions.php';
         $num_args = count($args);
 
-        if ($num_args == 1 && is_hash($args[0])) {
+        if (1 == $num_args && is_hash($args[0])) {
             $hash = is_null($this->joins) ? $args[0] : $this->prepend_table_name_to_fields($args[0]);
             $e = new Expressions($this->connection, $hash);
             $this->where = $e->to_s();

--- a/lib/Serialization.php
+++ b/lib/Serialization.php
@@ -171,7 +171,7 @@ abstract class Serialization
                 try {
                     $assoc = $this->model->$association;
 
-                    if ($assoc === null) {
+                    if (null === $assoc) {
                         $this->attributes[$association] = null;
                     } elseif (!is_array($assoc)) {
                         $serialized = new $serializer_class($assoc, $options);
@@ -305,7 +305,7 @@ class XmlSerializer extends Serialization
         $this->writer->endDocument();
         $xml = $this->writer->outputMemory(true);
 
-        if (@$this->options['skip_instruct'] == true) {
+        if (true == @$this->options['skip_instruct']) {
             $xml = preg_replace('/<\?xml version.*?\?>/', '', $xml);
         }
 
@@ -315,7 +315,7 @@ class XmlSerializer extends Serialization
     private function write($data, $tag=null)
     {
         foreach ($data as $attr => $value) {
-            if ($tag != null) {
+            if (null != $tag) {
                 $attr = $tag;
             }
 
@@ -348,7 +348,7 @@ class CsvSerializer extends Serialization
 
     public function to_s()
     {
-        if (@$this->options['only_header'] == true) {
+        if (true == @$this->options['only_header']) {
             return $this->header();
         }
 

--- a/lib/Singleton.php
+++ b/lib/Singleton.php
@@ -41,7 +41,7 @@ abstract class Singleton
     /**
      * Singleton objects should not be cloned.
      */
-    final private function __clone()
+    private function __clone()
     {
     }
 

--- a/lib/Table.php
+++ b/lib/Table.php
@@ -129,14 +129,14 @@ class Table
         foreach ($joins as $value) {
             $ret .= $space;
 
-            if (stripos($value, 'JOIN ') === false) {
+            if (false === stripos($value, 'JOIN ')) {
                 if (array_key_exists($value, $this->relationships)) {
                     $rel = $this->get_relationship($value);
 
                     // if there is more than 1 join for a given table we need to alias the table names
                     if (array_key_exists($rel->class_name, $existing_tables)) {
                         $alias = $value;
-                        $existing_tables[$rel->class_name]++;
+                        ++$existing_tables[$rel->class_name];
                     } else {
                         $existing_tables[$rel->class_name] = true;
                         $alias = null;
@@ -443,7 +443,7 @@ class Table
         $date_class = Config::instance()->get_date_class();
         foreach ($hash as $name => &$value) {
             if ($value instanceof $date_class || $value instanceof \DateTime) {
-                if (isset($this->columns[$name]) && $this->columns[$name]->type == Column::DATE) {
+                if (isset($this->columns[$name]) && Column::DATE == $this->columns[$name]->type) {
                     $hash[$name] = $this->conn->date_to_string($value);
                 } else {
                     $hash[$name] = $this->conn->datetime_to_string($value);

--- a/lib/Utils.php
+++ b/lib/Utils.php
@@ -110,7 +110,7 @@ function get_namespaces($class_name)
 
 function has_namespace($class_name)
 {
-    if (strpos($class_name, '\\') !== false) {
+    if (false !== strpos($class_name, '\\')) {
         return true;
     }
 
@@ -119,7 +119,7 @@ function has_namespace($class_name)
 
 function has_absolute_namespace($class_name)
 {
-    if (strpos($class_name, '\\') === 0) {
+    if (0 === strpos($class_name, '\\')) {
         return true;
     }
 
@@ -368,7 +368,7 @@ class Utils
 
     public static function pluralize_if($count, $string)
     {
-        if ($count == 1) {
+        if (1 == $count) {
             return $string;
         }
 

--- a/lib/Validations.php
+++ b/lib/Validations.php
@@ -485,7 +485,7 @@ class Validations
             if ($this->is_null_with_option($var, $options) || $this->is_blank_with_option($var, $options)) {
                 continue;
             }
-            if ($range_options[0] == 'within' || $range_options[0] == 'in') {
+            if ('within' == $range_options[0] || 'in' == $range_options[0]) {
                 $range = $options[$range_options[0]];
 
                 if (!(Utils::is_a('range', $range))) {
@@ -504,7 +504,7 @@ class Validations
                 if (is_float($option)) {
                     throw new  ValidationsArgumentError("$range_option value cannot use a float for length.");
                 }
-                if (!($range_option == 'maximum' && is_null($this->model->$attribute))) {
+                if (!('maximum' == $range_option && is_null($this->model->$attribute))) {
                     $messageOptions = ['is' => 'wrong_length', 'minimum' => 'too_short', 'maximum' => 'too_long'];
 
                     if (isset($options['message'])) {
@@ -581,7 +581,7 @@ class Validations
             $sql = '';
             $conditions = [''];
             $pk_quoted = $connection->quote_name($pk[0]);
-            if ($pk_value === null) {
+            if (null === $pk_value) {
                 $sql = "{$pk_quoted} IS NOT NULL";
             } else {
                 $sql = "{$pk_quoted} != ?";
@@ -732,7 +732,7 @@ class Errors implements IteratorAggregate
             $msg = self::$DEFAULT_ERROR_MESSAGES['blank'];
         }
 
-        if (($value = $this->model->$attribute) === '' || $value === null) {
+        if ('' === ($value = $this->model->$attribute) || null === $value) {
             $this->add($attribute, $msg);
         }
     }
@@ -760,7 +760,7 @@ class Errors implements IteratorAggregate
     {
         $errors = $this->$attribute;
 
-        return $errors && count($errors) == 1 ? $errors[0] : $errors;
+        return $errors && 1 == count($errors) ? $errors[0] : $errors;
     }
 
     /**

--- a/lib/adapters/MysqlAdapter.php
+++ b/lib/adapters/MysqlAdapter.php
@@ -37,17 +37,17 @@ class MysqlAdapter extends Connection
         $c = new Column();
         $c->inflected_name    = Inflector::instance()->variablize($column['field']);
         $c->name            = $column['field'];
-        $c->nullable        = ($column['null'] === 'YES' ? true : false);
-        $c->pk                = ($column['key'] === 'PRI' ? true : false);
-        $c->auto_increment    = ($column['extra'] === 'auto_increment' ? true : false);
+        $c->nullable        = ('YES' === $column['null'] ? true : false);
+        $c->pk                = ('PRI' === $column['key'] ? true : false);
+        $c->auto_increment    = ('auto_increment' === $column['extra'] ? true : false);
 
-        if ($column['type'] == 'timestamp' || $column['type'] == 'datetime') {
+        if ('timestamp' == $column['type'] || 'datetime' == $column['type']) {
             $c->raw_type = 'datetime';
             $c->length = 19;
-        } elseif ($column['type'] == 'date') {
+        } elseif ('date' == $column['type']) {
             $c->raw_type = 'date';
             $c->length = 10;
-        } elseif ($column['type'] == 'time') {
+        } elseif ('time' == $column['type']) {
             $c->raw_type = 'time';
             $c->length = 8;
         } else {

--- a/lib/adapters/OciAdapter.php
+++ b/lib/adapters/OciAdapter.php
@@ -98,14 +98,14 @@ class OciAdapter extends Connection
         $column['column_name'] = strtolower($column['column_name']);
         $column['data_type'] = strtolower(preg_replace('/\(.*?\)/', '', $column['data_type']));
 
-        if ($column['data_default'] !== null) {
+        if (null !== $column['data_default']) {
             $column['data_default'] = trim($column['data_default'], "' ");
         }
 
-        if ($column['data_type'] == 'number') {
+        if ('number' == $column['data_type']) {
             if ($column['data_scale'] > 0) {
                 $column['data_type'] = 'decimal';
-            } elseif ($column['data_scale'] == 0) {
+            } elseif (0 == $column['data_scale']) {
                 $column['data_type'] = 'int';
             }
         }
@@ -113,11 +113,11 @@ class OciAdapter extends Connection
         $c = new Column();
         $c->inflected_name    = Inflector::instance()->variablize($column['column_name']);
         $c->name            = $column['column_name'];
-        $c->nullable        = $column['nullable'] == 'Y' ? true : false;
-        $c->pk                = $column['pk'] == 'P' ? true : false;
+        $c->nullable        = 'Y' == $column['nullable'] ? true : false;
+        $c->pk                = 'P' == $column['pk'] ? true : false;
         $c->length            = $column['data_length'];
 
-        if ($column['data_type'] == 'timestamp') {
+        if ('timestamp' == $column['data_type']) {
             $c->raw_type = 'datetime';
         } else {
             $c->raw_type = $column['data_type'];

--- a/lib/adapters/PgsqlAdapter.php
+++ b/lib/adapters/PgsqlAdapter.php
@@ -80,10 +80,10 @@ SQL;
         $c->pk                = ($column['pk'] ? true : false);
         $c->auto_increment    = false;
 
-        if (substr($column['type'], 0, 9) == 'timestamp') {
+        if ('timestamp' == substr($column['type'], 0, 9)) {
             $c->raw_type = 'datetime';
             $c->length = 19;
-        } elseif ($column['type'] == 'date') {
+        } elseif ('date' == $column['type']) {
             $c->raw_type = 'date';
             $c->length = 10;
         } else {
@@ -102,7 +102,7 @@ SQL;
         if ($column['default']) {
             preg_match("/^nextval\('(.*)'\)$/", $column['default'], $matches);
 
-            if (count($matches) == 2) {
+            if (2 == count($matches)) {
                 $c->sequence = $matches[1];
             } else {
                 $c->default = $c->cast($column['default'], $this);

--- a/lib/adapters/SqliteAdapter.php
+++ b/lib/adapters/SqliteAdapter.php
@@ -69,16 +69,16 @@ class SqliteAdapter extends Connection
 
         $c->map_raw_type();
 
-        if ($c->type == Column::DATETIME) {
+        if (Column::DATETIME == $c->type) {
             $c->length = 19;
-        } elseif ($c->type == Column::DATE) {
+        } elseif (Column::DATE == $c->type) {
             $c->length = 10;
         }
 
         // From SQLite3 docs: The value is a signed integer, stored in 1, 2, 3, 4, 6,
         // or 8 bytes depending on the magnitude of the value.
         // so is it ok to assume it's possible an int can always go up to 8 bytes?
-        if ($c->type == Column::INTEGER && !$c->length) {
+        if (Column::INTEGER == $c->type && !$c->length) {
             $c->length = 8;
         }
 

--- a/test/ActiveRecordFindTest.php
+++ b/test/ActiveRecordFindTest.php
@@ -171,7 +171,7 @@ class ActiveRecordFindTest extends DatabaseTest
 
     public function test_find_with_conditions()
     {
-        $author = Author::find(['conditions' => ['author_id=? and name=?', 1, 'Tito']]);
+        $author = Author::find("first", ['conditions' => ['author_id=? and name=?', 1, 'Tito']]);
         $this->assert_equals(1, $author->author_id);
     }
 

--- a/test/ActiveRecordFindTest.php
+++ b/test/ActiveRecordFindTest.php
@@ -30,7 +30,7 @@ class ActiveRecordFindTest extends DatabaseTest
             Author::find(1, 999999999);
             $this->fail();
         } catch (ActiveRecord\RecordNotFound $e) {
-            $this->assert_true(strpos($e->getMessage(), 'found 1, but was looking for 2') !== false);
+            $this->assert_true(false !== strpos($e->getMessage(), 'found 1, but was looking for 2'));
         }
     }
 
@@ -38,7 +38,7 @@ class ActiveRecordFindTest extends DatabaseTest
     {
         $author = Author::find(3, ['order' => 'name']);
         $this->assert_equals(3, $author->id);
-        $this->assert_true(strpos(Author::table()->last_sql, 'ORDER BY name') !== false);
+        $this->assert_true(false !== strpos(Author::table()->last_sql, 'ORDER BY name'));
     }
 
     public function test_find_by_pk_array()
@@ -53,7 +53,7 @@ class ActiveRecordFindTest extends DatabaseTest
     {
         $authors = Author::find(1, '2', ['order' => 'name']);
         $this->assert_equals(2, count($authors));
-        $this->assert_true(strpos(Author::table()->last_sql, 'ORDER BY name') !== false);
+        $this->assert_true(false !== strpos(Author::table()->last_sql, 'ORDER BY name'));
     }
 
     /**
@@ -203,7 +203,7 @@ class ActiveRecordFindTest extends DatabaseTest
 
         foreach ($res as $author) {
             $this->assert_true($author instanceof ActiveRecord\Model);
-            $i++;
+            ++$i;
         }
         $this->assert_true($i > 0);
     }
@@ -214,7 +214,7 @@ class ActiveRecordFindTest extends DatabaseTest
 
         foreach (Author::all() as $author) {
             $this->assert_true($author instanceof ActiveRecord\Model);
-            $i++;
+            ++$i;
         }
         $this->assert_true($i > 0);
     }

--- a/test/ActiveRecordFindTest.php
+++ b/test/ActiveRecordFindTest.php
@@ -171,7 +171,7 @@ class ActiveRecordFindTest extends DatabaseTest
 
     public function test_find_with_conditions()
     {
-        $author = Author::find("first", ['conditions' => ['author_id=? and name=?', 1, 'Tito']]);
+        $author = Author::find('first', ['conditions' => ['author_id=? and name=?', 1, 'Tito']]);
         $this->assert_equals(1, $author->author_id);
     }
 

--- a/test/ActiveRecordTest.php
+++ b/test/ActiveRecordTest.php
@@ -110,8 +110,8 @@ class ActiveRecordTest extends DatabaseTest
 
     public function test_get_values_for()
     {
-        $book = Book::find_by_name('Ancient Art of Main Tanking');
-        $ret = $book->get_values_for(['book_id', 'author_id']);
+        $books = Book::find_by_name('Ancient Art of Main Tanking');
+        $ret = $books[0]->get_values_for(['book_id', 'author_id']);
         $this->assert_equals(['book_id', 'author_id'], array_keys($ret));
         $this->assert_equals([1, 1], array_values($ret));
     }

--- a/test/ActiveRecordTest.php
+++ b/test/ActiveRecordTest.php
@@ -111,7 +111,7 @@ class ActiveRecordTest extends DatabaseTest
     public function test_get_values_for()
     {
         $books = Book::find_by_name('Ancient Art of Main Tanking');
-        $ret = $books[0]->get_values_for(['book_id', 'author_id']);
+        $ret = $books->get_values_for(['book_id', 'author_id']);
         $this->assert_equals(['book_id', 'author_id'], array_keys($ret));
         $this->assert_equals([1, 1], array_values($ret));
     }

--- a/test/ActiveRecordWriteTest.php
+++ b/test/ActiveRecordWriteTest.php
@@ -67,7 +67,7 @@ class ActiveRecordWriteTest extends DatabaseTest
     {
         $author = new Author(['name' => 'Blah Blah']);
         $author->save();
-        $this->assert_true(strpos($author->connection()->last_query, $author->connection()->quote_name('updated_at')) !== false);
+        $this->assert_true(false !== strpos($author->connection()->last_query, $author->connection()->quote_name('updated_at')));
     }
 
     public function test_save_auto_increment_id()
@@ -131,7 +131,7 @@ class ActiveRecordWriteTest extends DatabaseTest
         $book = Book::find(1);
         $book->name = 'new name';
         $book->save();
-        $this->assert_true(strpos($book->connection()->last_query, $book->connection()->quote_name('name')) !== false);
+        $this->assert_true(false !== strpos($book->connection()->last_query, $book->connection()->quote_name('name')));
     }
 
     public function test_update_attributes()
@@ -214,8 +214,8 @@ class ActiveRecordWriteTest extends DatabaseTest
     public function test_dirty_attributes_cleared_after_saving()
     {
         $book = $this->make_new_book_and();
-        $this->assert_true(strpos($book->table()->last_sql, 'name') !== false);
-        $this->assert_true(strpos($book->table()->last_sql, 'special') !== false);
+        $this->assert_true(false !== strpos($book->table()->last_sql, 'name'));
+        $this->assert_true(false !== strpos($book->table()->last_sql, 'special'));
         $this->assert_equals(null, $book->dirty_attributes());
     }
 
@@ -390,7 +390,7 @@ class ActiveRecordWriteTest extends DatabaseTest
 
         $num_affected = Author::delete_all(['conditions' => ['parent_author_id = ?', 2], 'limit' => 1, 'order' => 'name asc']);
         $this->assert_equals(1, $num_affected);
-        $this->assert_true(strpos(Author::table()->last_sql, 'ORDER BY name asc LIMIT 1') !== false);
+        $this->assert_true(false !== strpos(Author::table()->last_sql, 'ORDER BY name asc LIMIT 1'));
     }
 
     public function test_update_all_with_set_as_string()
@@ -435,7 +435,7 @@ class ActiveRecordWriteTest extends DatabaseTest
 
         $num_affected = Author::update_all(['set' => 'parent_author_id = 2', 'limit' => 1, 'order' => 'name asc']);
         $this->assert_equals(1, $num_affected);
-        $this->assert_true(strpos(Author::table()->last_sql, 'ORDER BY name asc LIMIT 1') !== false);
+        $this->assert_true(false !== strpos(Author::table()->last_sql, 'ORDER BY name asc LIMIT 1'));
     }
 
     public function test_update_native_datetime()

--- a/test/CallbackTest.php
+++ b/test/CallbackTest.php
@@ -237,7 +237,7 @@ class CallBackTest extends DatabaseTest
 
         $this->assert_true($i_should_have_ran);
         $this->assert_false($i_ran);
-        $this->assert_true(strpos(ActiveRecord\Table::load('VenueCB')->last_sql, 'INSERT') === false);
+        $this->assert_true(false === strpos(ActiveRecord\Table::load('VenueCB')->last_sql, 'INSERT'));
     }
 
     public function test_before_save_returned_false_halts_execution()
@@ -259,7 +259,7 @@ class CallBackTest extends DatabaseTest
         $this->assert_true($i_should_have_ran);
         $this->assert_false($i_ran);
         $this->assert_false($ret);
-        $this->assert_true(strpos(ActiveRecord\Table::load('VenueCB')->last_sql, 'UPDATE') === false);
+        $this->assert_true(false === strpos(ActiveRecord\Table::load('VenueCB')->last_sql, 'UPDATE'));
     }
 
     public function test_before_destroy_returned_false_halts_execution()
@@ -277,7 +277,7 @@ class CallBackTest extends DatabaseTest
 
         $this->assert_false($i_ran);
         $this->assert_false($ret);
-        $this->assert_true(strpos(ActiveRecord\Table::load('VenueCB')->last_sql, 'DELETE') === false);
+        $this->assert_true(false === strpos(ActiveRecord\Table::load('VenueCB')->last_sql, 'DELETE'));
     }
 
     public function test_before_validation_returned_false_halts_execution()
@@ -291,6 +291,6 @@ class CallBackTest extends DatabaseTest
         $ret = $v->save();
 
         $this->assert_false($ret);
-        $this->assert_true(strpos(ActiveRecord\Table::load('VenueCB')->last_sql, 'UPDATE') === false);
+        $this->assert_true(false === strpos(ActiveRecord\Table::load('VenueCB')->last_sql, 'UPDATE'));
     }
 }

--- a/test/ColumnTest.php
+++ b/test/ColumnTest.php
@@ -27,7 +27,7 @@ class ColumnTest extends SnakeCase_PHPUnit_Framework_TestCase
         $this->column->type = $type;
         $value = $this->column->cast($original_value, $this->conn);
 
-        if ($original_value != null && ($type == Column::DATETIME || $type == Column::DATE)) {
+        if (null != $original_value && (Column::DATETIME == $type || Column::DATE == $type)) {
             $this->assert_true($value instanceof DateTime);
         } else {
             $this->assert_same($casted_value, $value);

--- a/test/MysqlAdapterTest.php
+++ b/test/MysqlAdapterTest.php
@@ -32,6 +32,6 @@ class MysqlAdapterTest extends AdapterTest
         $sql = 'SELECT * FROM authors ORDER BY name ASC';
         $this->conn->query_and_fetch($this->conn->limit($sql, null, 1), function ($row) use (&$ret) { $ret[] = $row; });
 
-        $this->assert_true(strpos($this->conn->last_query, 'LIMIT 1') !== false);
+        $this->assert_true(false !== strpos($this->conn->last_query, 'LIMIT 1'));
     }
 }

--- a/test/RelationshipTest.php
+++ b/test/RelationshipTest.php
@@ -169,7 +169,7 @@ class RelationshipTest extends DatabaseTest
             $event->venue->name;
             $this->fail('expected Exception ActiveRecord\UndefinedPropertyException');
         } catch (ActiveRecord\UndefinedPropertyException $e) {
-            $this->assert_true(strpos($e->getMessage(), 'name') !== false);
+            $this->assert_true(false !== strpos($e->getMessage(), 'name'));
         }
     }
 
@@ -273,7 +273,7 @@ class RelationshipTest extends DatabaseTest
             $venue->events[0]->description;
             $this->fail('expected Exception ActiveRecord\UndefinedPropertyException');
         } catch (ActiveRecord\UndefinedPropertyException $e) {
-            $this->assert_true(strpos($e->getMessage(), 'description') !== false);
+            $this->assert_true(false !== strpos($e->getMessage(), 'description'));
         }
     }
 
@@ -381,7 +381,7 @@ class RelationshipTest extends DatabaseTest
         Venue::$has_many[1] = ['hosts', 'through' => 'events', 'conditions' => ['events.title != ?', 'Love Overboard']];
 
         $venue = $this->get_relationship();
-        $this->assert_true(count($venue->hosts) === 1);
+        $this->assert_true(1 === count($venue->hosts));
         $this->assert_sql_has('events.title !=', ActiveRecord\Table::load('Host')->last_sql);
     }
 
@@ -422,7 +422,7 @@ class RelationshipTest extends DatabaseTest
             $this->assert_equals($book->secondary_author_id, $author->parent_author_id);
         }
 
-        $this->assert_true(strpos(ActiveRecord\Table::load('Book')->last_sql, 'secondary_author_id') !== false);
+        $this->assert_true(false !== strpos(ActiveRecord\Table::load('Book')->last_sql, 'secondary_author_id'));
         Author::$has_many = $old;
     }
 
@@ -447,7 +447,7 @@ class RelationshipTest extends DatabaseTest
             $employee->position->active;
             $this->fail('expected Exception ActiveRecord\UndefinedPropertyException');
         } catch (ActiveRecord\UndefinedPropertyException $e) {
-            $this->assert_true(strpos($e->getMessage(), 'active') !== false);
+            $this->assert_true(false !== strpos($e->getMessage(), 'active'));
         }
     }
 
@@ -509,7 +509,7 @@ class RelationshipTest extends DatabaseTest
 
         $book = Book::find(1);
         $this->assert_equals($book->secondary_author_id, $book->explicit_author->parent_author_id);
-        $this->assert_true(strpos(ActiveRecord\Table::load('Author')->last_sql, 'parent_author_id') !== false);
+        $this->assert_true(false !== strpos(ActiveRecord\Table::load('Author')->last_sql, 'parent_author_id'));
     }
 
     public function test_dont_attempt_to_load_if_all_foreign_keys_are_null()

--- a/test/SQLBuilderTest.php
+++ b/test/SQLBuilderTest.php
@@ -27,7 +27,7 @@ class SQLBuilderTest extends DatabaseTest
         $this->assert_sql_has($expected_sql, array_shift($cond));
 
         if ($values) {
-            $this->assert_equals(array_values(array_filter($values, function ($s) { return $s !== null; })), array_values($cond));
+            $this->assert_equals(array_values(array_filter($values, function ($s) { return null !== $s; })), array_values($cond));
         } else {
             $this->assert_equals([], $cond);
         }

--- a/test/SqliteAdapterTest.php
+++ b/test/SqliteAdapterTest.php
@@ -39,7 +39,7 @@ class SqliteAdapterTest extends AdapterTest
         $sql = 'SELECT * FROM authors ORDER BY name ASC';
         $this->conn->query_and_fetch($this->conn->limit($sql, null, 1), function ($row) use (&$ret) { $ret[] = $row; });
 
-        $this->assert_true(strpos($this->conn->last_query, 'LIMIT 1') !== false);
+        $this->assert_true(false !== strpos($this->conn->last_query, 'LIMIT 1'));
     }
 
     public function test_gh183_sqliteadapter_autoincrement()

--- a/test/ValidatesNumericalityOfTest.php
+++ b/test/ValidatesNumericalityOfTest.php
@@ -32,7 +32,7 @@ class ValidatesNumericalityOfTest extends DatabaseTest
         $book = new BookNumericality();
         $book->numeric_test = $value;
 
-        if ($boolean == 'valid') {
+        if ('valid' == $boolean) {
             $this->assert_true($book->save());
             $this->assert_false($book->errors->is_invalid('numeric_test'));
         } else {

--- a/test/ValidationsTest.php
+++ b/test/ValidationsTest.php
@@ -13,7 +13,7 @@ class BookValidations extends ActiveRecord\Model
     // fired for every validation - but only used for custom validation test
     public function validate()
     {
-        if ($this->name == 'test_custom_validation') {
+        if ('test_custom_validation' == $this->name) {
             $this->errors->add('name', self::$custom_validator_error_msg);
         }
     }
@@ -163,7 +163,7 @@ class ValidationsTest extends DatabaseTest
     {
         $book = new BookValidations();
         $book->is_valid();
-        $this->assert_true(strpos(serialize($book->errors), 'model";N;') !== false);
+        $this->assert_true(false !== strpos(serialize($book->errors), 'model";N;'));
     }
 
     public function test_validations_takes_strings()

--- a/test/helpers/AdapterTest.php
+++ b/test/helpers/AdapterTest.php
@@ -9,7 +9,7 @@ class AdapterTest extends DatabaseTest
     public function set_up($connection_name=null)
     {
         if (($connection_name && !in_array($connection_name, PDO::getAvailableDrivers())) ||
-            ActiveRecord\Config::instance()->get_connection($connection_name) == 'skip') {
+            'skip' == ActiveRecord\Config::instance()->get_connection($connection_name)) {
             $this->mark_test_skipped($connection_name . ' drivers are not present');
         }
 
@@ -98,7 +98,7 @@ class AdapterTest extends DatabaseTest
         }
         $connection_string = "{$connection_string}@{$url['host']}:$port{$url['path']}";
 
-        if ($this->conn->protocol != 'sqlite') {
+        if ('sqlite' != $this->conn->protocol) {
             ActiveRecord\Connection::instance($connection_string);
         }
     }
@@ -270,7 +270,7 @@ class AdapterTest extends DatabaseTest
         $names = ['author_id', 'parent_author_id', 'name', 'updated_at', 'created_at', 'some_Date', 'some_time', 'some_text', 'encrypted_password', 'mixedCaseField'];
 
         if ($this->conn instanceof ActiveRecord\OciAdapter) {
-            $names = array_filter(array_map('strtolower', $names), function ($s) { return $s !== 'some_time'; });
+            $names = array_filter(array_map('strtolower', $names), function ($s) { return 'some_time' !== $s; });
         }
 
         foreach ($names as $field) {

--- a/test/helpers/DatabaseLoader.php
+++ b/test/helpers/DatabaseLoader.php
@@ -13,7 +13,7 @@ class DatabaseLoader
             static::$instances[$db->protocol] = 0;
         }
 
-        if (static::$instances[$db->protocol]++ == 0) {
+        if (0 == static::$instances[$db->protocol]++) {
             // drop and re-create the tables one time only
             $this->drop_tables();
             $this->exec_sql_script($db->protocol);
@@ -23,7 +23,7 @@ class DatabaseLoader
     public function reset_table_data()
     {
         foreach ($this->get_fixture_tables() as $table) {
-            if ($this->db->protocol == 'oci' && $table == 'rm-bldg') {
+            if ('oci' == $this->db->protocol && 'rm-bldg' == $table) {
                 continue;
             }
 
@@ -44,10 +44,10 @@ class DatabaseLoader
         $tables = $this->db->tables();
 
         foreach ($this->get_fixture_tables() as $table) {
-            if ($this->db->protocol == 'oci') {
+            if ('oci' == $this->db->protocol) {
                 $table = strtoupper($table);
 
-                if ($table == 'RM-BLDG') {
+                if ('RM-BLDG' == $table) {
                     continue;
                 }
             }
@@ -56,7 +56,7 @@ class DatabaseLoader
                 $this->db->query('DROP TABLE ' . $this->quote_name($table));
             }
 
-            if ($this->db->protocol == 'oci') {
+            if ('oci' == $this->db->protocol) {
                 try {
                     $this->db->query("DROP SEQUENCE {$table}_seq");
                 } catch (ActiveRecord\DatabaseException $e) {
@@ -69,7 +69,7 @@ class DatabaseLoader
     public function exec_sql_script($file)
     {
         foreach (explode(';', $this->get_sql($file)) as $sql) {
-            if (trim($sql) != '') {
+            if ('' != trim($sql)) {
                 $this->db->query($sql);
             }
         }
@@ -122,7 +122,7 @@ class DatabaseLoader
 
     public function quote_name($name)
     {
-        if ($this->db->protocol == 'oci') {
+        if ('oci' == $this->db->protocol) {
             $name = strtoupper($name);
         }
 

--- a/test/helpers/DatabaseTest.php
+++ b/test/helpers/DatabaseTest.php
@@ -21,7 +21,7 @@ class DatabaseTest extends SnakeCase_PHPUnit_Framework_TestCase
             $config->set_default_connection($connection_name);
         }
 
-        if ($connection_name == 'sqlite' || $config->get_default_connection() == 'sqlite') {
+        if ('sqlite' == $connection_name || 'sqlite' == $config->get_default_connection()) {
             // need to create the db. the adapter specifically does not create it for us.
             static::$db = substr(ActiveRecord\Config::instance()->get_connection('sqlite'), 9);
             new SQLite3(static::$db);

--- a/test/helpers/config.php
+++ b/test/helpers/config.php
@@ -30,7 +30,7 @@ $GLOBALS['slow_tests'] = false;
 // whether or not to show warnings when Log or Memcache is missing
 $GLOBALS['show_warnings'] = true;
 
-if (getenv('LOG') !== 'false') {
+if ('false' !== getenv('LOG')) {
     DatabaseTest::$log = true;
 }
 
@@ -45,9 +45,9 @@ ActiveRecord\Config::initialize(function ($cfg) {
     $cfg->set_default_connection('mysql');
 
     for ($i=0; $i<count($GLOBALS['argv']); ++$i) {
-        if ($GLOBALS['argv'][$i] == '--adapter') {
+        if ('--adapter' == $GLOBALS['argv'][$i]) {
             $cfg->set_default_connection($GLOBALS['argv'][$i+1]);
-        } elseif ($GLOBALS['argv'][$i] == '--slow-tests') {
+        } elseif ('--slow-tests' == $GLOBALS['argv'][$i]) {
             $GLOBALS['slow_tests'] = true;
         }
     }

--- a/test/models/Author.php
+++ b/test/models/Author.php
@@ -3,8 +3,8 @@
 class Author extends ActiveRecord\Model
 {
     public static $pk = 'author_id';
-//	static $has_one = array(array('awesome_person', 'foreign_key' => 'author_id', 'primary_key' => 'author_id'),
-//	array('parent_author', 'class_name' => 'Author', 'foreign_key' => 'parent_author_id'));
+    //	static $has_one = array(array('awesome_person', 'foreign_key' => 'author_id', 'primary_key' => 'author_id'),
+    //	array('parent_author', 'class_name' => 'Author', 'foreign_key' => 'parent_author_id'));
     public static $has_many = ['books'];
     public static $has_one = [
         ['awesome_person', 'foreign_key' => 'author_id', 'primary_key' => 'author_id'],

--- a/test/models/VenueAfterCreate.php
+++ b/test/models/VenueAfterCreate.php
@@ -7,7 +7,7 @@ class VenueAfterCreate extends ActiveRecord\Model
 
     public function change_name_after_create_if_name_is_change_me()
     {
-        if ($this->name == 'change me') {
+        if ('change me' == $this->name) {
             $this->name = 'changed!';
             $this->save();
         }


### PR DESCRIPTION
Fix more return type annotations for static analysis.

Also fixing something that's been broken for years: the return type of `find_by_pk` should be dependent on the type of the argument passed in (array or scalar), not on the number of results found.

I'm also turning off cs-fixer for now; not prepared to deal with it, and I don't dare let it do all the fixes it wants to do (it's got a history of being pretty buggy).