### PR TITLE
Fix deprecation warnings in PHP 8.2

### DIFF
--- a/lib/Model.php
+++ b/lib/Model.php
@@ -1551,7 +1551,7 @@ class Model
      */
     public static function all(/* ... */)
     {
-        return call_user_func_array('static::find', array_merge(['all'], func_get_args()));
+        return call_user_func_array(static::class.'::find', array_merge(['all'], func_get_args()));
     }
 
     /**
@@ -1575,7 +1575,7 @@ class Model
             if (is_hash($args[0])) {
                 $options['conditions'] = $args[0];
             } else {
-                $options['conditions'] = call_user_func_array('static::pk_conditions', $args);
+                $options['conditions'] = call_user_func_array(static::class.'::pk_conditions', $args);
             }
         }
 
@@ -1601,7 +1601,7 @@ class Model
      */
     public static function exists(/* ... */)
     {
-        return call_user_func_array('static::count', func_get_args()) > 0 ? true : false;
+        return call_user_func_array(static::class.'::count', func_get_args()) > 0 ? true : false;
     }
 
     /**
@@ -1613,7 +1613,7 @@ class Model
      */
     public static function first(/* ... */)
     {
-        return call_user_func_array('static::find', array_merge(['first'], func_get_args()));
+        return call_user_func_array(static::class.'::find', array_merge(['first'], func_get_args()));
     }
 
     /**

--- a/lib/Relationship.php
+++ b/lib/Relationship.php
@@ -708,6 +708,8 @@ class BelongsTo extends AbstractRelationship
 {
     public function __construct($options=[])
     {
+        private $primary_key;
+
         parent::__construct($options);
 
         if (!$this->class_name) {

--- a/lib/Validations.php
+++ b/lib/Validations.php
@@ -43,6 +43,7 @@ use IteratorAggregate;
  */
 class Validations
 {
+    private $klass;
     private $model;
     private $options = [];
     private $validators = [];


### PR DESCRIPTION
Fixed issue #23:

Creation of dynamic property ActiveRecord\Validations::$klass fixed by declaring the variable at the top of the class. 

Deprecated: Use of "static" in callables is deprecated fixed by using the static::class magic keyword.