### PR TITLE
A cleaner PR

### DIFF
--- a/lib/Model.php
+++ b/lib/Model.php
@@ -1625,7 +1625,7 @@ class Model
      */
     public static function last(/* ... */)
     {
-        return call_user_func_array('static::find', array_merge(['last'], func_get_args()));
+        return call_user_func_array(static::class.'::find', array_merge(['last'], func_get_args()));
     }
 
     /**


### PR DESCRIPTION
My apologies; I should have done a search in the repository of 'static:: to find all instances of this deprecation error. There's one more in Model.last(). Found and fixed.