### PR TITLE
Fixed using ${var} in strings is deprecated in PHP 8.2

### DIFF
--- a/lib/Model.php
+++ b/lib/Model.php
@@ -372,7 +372,7 @@ class Model
         }
 
         // check for getters
-        if (method_exists($this, "get_${attribute_name}")) {
+        if (method_exists($this, "get_{$attribute_name}")) {
             return true;
         }
 


### PR DESCRIPTION
Fix for issue #29 as per https://php.watch/versions/8.2/$%7Bvar%7D-string-interpolation-deprecated

