### PR TITLE
Fix test deprecations

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,13 +18,13 @@ After that you can run the tests by invoking the local PHPUnit
 To run all test simply use:
 
 ```sh
-vendor/bin/phpunit
+composer test
 ```
 
 Or run a single test file by specifying its path:
 
 ```sh
-vendor/bin/phpunit test/InflectorTest.php
+composer test test/InflectorTest.php
 ```
 
 #### Skipped Tests ####
@@ -36,14 +36,14 @@ tests, pass the `--verbose` flag to PHPUnit:
 vendor/bin/phpunit --verbose
 ```
 
-For Docker users, a docker-compose.yml has been provided in the project root that will provide:
+For [Docker](https://docs.docker.com/get-docker/) users, a docker-compose.yml has been provided in the project root that will provide:
 - mysql
 - postgres
 - memcached
 
 Simply run:
 ```shell
-docker-composer up -d
+docker-compose up -d
 ```
 
 Then, the necessary services will be available and the tests should pass (although you may need to install PHP memcache extensions in a separate step, see below ).
@@ -63,10 +63,16 @@ Download the .dll that matches your version of PHP, install it into your /ext di
 extension=memcache
 ```
 
-
 #### Alternate setup
 If Docker is not available to you, or you would simply not use it, you will have to do your best to install the various services on your own.
 
 * Install `memcached` and the PHP memcached extension (e.g., `brew install php56-memcache memcached` on macOS)
 * Install the PDO drivers for PostgreSQL (e.g., `brew install php56-pdo-pgsql` on macOS)
 * Create a MySQL database and a PostgreSQL database. You can either create these such that they are available at the default locations of `mysql://test:test@127.0.0.1/test` and `pgsql://test:test@127.0.0.1/test` respectively. Alternatively, you can set the `PHPAR_MYSQL` and `PHPAR_PGSQL` environment variables to specify a different location for the MySQL and PostgreSQL databases.
+
+#### Static checks
+
+* You can check your code with a PSR-2 style checker locally with the command:
+```sh
+composer style-check
+```

--- a/README.md
+++ b/README.md
@@ -6,21 +6,13 @@
 
 This is a badly-needed relaunch of the project originally created by Kien La and Jacques Fuentes. Both authors and the current maintainers have lost interest in PHP, moved onto other languages, and no longer review pull requests or issues. Some of us still depend on the project and want to see it move forward, so we've moved it here under new ownership. 
 
-
-The code has been refreshed with a number of improvements:
-
-* A PSR-2 style checker has been added to the travis build, and a fixer has been run on the codebase. You can check your code locally with the command:
-    ```sh
-    composer style-check
-    ```
-* API and Usage documentation is now automatically generated and deployed to github pages. You'll find the usage documentation in `/docs` if you want to make any changes.  
-
-
 Note that the original website, <http://www.phpactiverecord.org/>, has also fallen into neglect and disrepair, and is not 
  advised as a primary reference. A new documentation site has been launched here: 
  
 http://php-activerecord.github.io/activerecord/
- 
+
+and can be found in in `/docs` if you want to make any changes.
+
 ## Installation
 
 Via composer:
@@ -47,14 +39,13 @@ Of course, there are some differences which will be obvious to the user if they 
 ## Minimum Requirements ##
 
 - PHP 8.1+
-- PDO driver for your respective database
+- [PDO driver for your respective database](https://www.php.net/manual/en/pdo.installation.php)
 
 ## Supported Databases ##
 
 - MySQL
 - SQLite
 - PostgreSQL
-- Oracle
 
 ## Features ##
 
@@ -81,41 +72,14 @@ Setup is very easy and straight-forward. There are essentially only three config
 Example:
 
 ```php
-ActiveRecord\Config::initialize(function($cfg)
-{
-   $cfg->set_model_directory('/path/to/your/model_directory');
-   $cfg->set_connections(
-     array(
-       'development' => 'mysql://username:password@localhost/development_database_name',
-       'test' => 'mysql://username:password@localhost/test_database_name',
-       'production' => 'mysql://username:password@localhost/production_database_name'
-     )
-   );
-});
-```
-
-Alternatively (w/o the 5.3 closure):
-
-```php
 $cfg = ActiveRecord\Config::instance();
 $cfg->set_model_directory('/path/to/your/model_directory');
-$cfg->set_connections(
-  array(
+$cfg->set_connections([
     'development' => 'mysql://username:password@localhost/development_database_name',
     'test' => 'mysql://username:password@localhost/test_database_name',
     'production' => 'mysql://username:password@localhost/production_database_name'
-  )
-);
-```
-
-PHP ActiveRecord will default to use your development database. For testing or production, you simply set the default
-connection according to your current environment ('test' or 'production'):
-
-```php
-ActiveRecord\Config::initialize(function($cfg)
-{
-  $cfg->set_default_connection(your_environment);
-});
+]);
+$cfg->set_default_connection('development'); // Set to development | test | production, development is default
 ```
 
 Once you have configured these three settings you are done. ActiveRecord takes care of the rest for you.

--- a/lib/Relationship.php
+++ b/lib/Relationship.php
@@ -461,6 +461,7 @@ class HasMany extends AbstractRelationship
     protected $primary_key;
 
     private $has_one = false;
+    private $initialized;
     private $through;
 
     /**
@@ -709,6 +710,10 @@ class HasAndBelongsToMany extends AbstractRelationship
  */
 class BelongsTo extends AbstractRelationship
 {
+    public $class_name;
+    public $foreign_key;
+    public $primary_key;
+
     public function __construct($options=[])
     {
         parent::__construct($options);

--- a/lib/Relationship.php
+++ b/lib/Relationship.php
@@ -712,7 +712,6 @@ class BelongsTo extends AbstractRelationship
 {
     public $class_name;
     public $foreign_key;
-    public $primary_key;
 
     public function __construct($options=[])
     {
@@ -731,7 +730,7 @@ class BelongsTo extends AbstractRelationship
     public function __get($name)
     {
         if ('primary_key' === $name && !isset($this->primary_key)) {
-            $this->primary_key = [Table::load($this->class_name)->pk[0]];
+            return [Table::load($this->class_name)->pk[0]];
         }
 
         return $this->$name;

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,26 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit
-    displayDetailsOnTestsThatTriggerDeprecations="true"
-    displayDetailsOnSkippedTests="true"
-    displayDetailsOnTestsThatTriggerWarnings="true"
-    displayDetailsOnTestsThatTriggerNotices="true"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    backupGlobals="false"
-    colors="true"
-    processIsolation="false"
-    stopOnFailure="false"
-    bootstrap="test/helpers/config.php"
-    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.3/phpunit.xsd"
-    cacheDirectory=".phpunit.cache"
-    backupStaticProperties="false">
-    <coverage>
-        <include>
-            <directory suffix=".php">./lib</directory>
-        </include>
-    </coverage>
-    <testsuites>
-        <testsuite name="PHP ActiveRecord Test Suite">
-          <directory>./test/</directory>
-        </testsuite>
-    </testsuites>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" displayDetailsOnTestsThatTriggerDeprecations="true" displayDetailsOnSkippedTests="true" displayDetailsOnTestsThatTriggerWarnings="true" displayDetailsOnTestsThatTriggerNotices="true" backupGlobals="false" colors="true" processIsolation="false" stopOnFailure="false" bootstrap="test/helpers/config.php" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.3/phpunit.xsd" cacheDirectory=".phpunit.cache" backupStaticProperties="false">
+  <coverage/>
+  <testsuites>
+    <testsuite name="PHP ActiveRecord Test Suite">
+      <directory>./test/</directory>
+    </testsuite>
+  </testsuites>
+  <source>
+    <include>
+      <directory suffix=".php">./lib</directory>
+    </include>
+  </source>
 </phpunit>

--- a/test/ActiveRecordTest.php
+++ b/test/ActiveRecordTest.php
@@ -13,6 +13,8 @@ use test\models\Venue;
 
 class ActiveRecordTest extends DatabaseTestCase
 {
+    private $options;
+    
     public function setUp($connection_name=null): void
     {
         parent::setUp($connection_name);

--- a/test/ActiveRecordWriteTest.php
+++ b/test/ActiveRecordWriteTest.php
@@ -11,14 +11,12 @@ use test\models\Book;
 
 class DirtyAuthor extends ActiveRecord\Model
 {
-    private $name;
-
     public static $table = 'authors';
     public static $before_save = 'before_save';
 
     public function before_save()
     {
-        $this->name = 'i saved';
+        $this->assign_attribute('name', 'i saved');
     }
 }
 
@@ -330,6 +328,7 @@ class ActiveRecordWriteTest extends DatabaseTestCase
         $author->encrypted_password = 'coco';
         $author->save();
         $this->assertEquals('i saved', DirtyAuthor::find($author->id)->name);
+        $this->assertEquals('coco', DirtyAuthor::find($author->id)->encrypted_password);
     }
 
     public function test_is_dirty()

--- a/test/ActiveRecordWriteTest.php
+++ b/test/ActiveRecordWriteTest.php
@@ -11,6 +11,8 @@ use test\models\Book;
 
 class DirtyAuthor extends ActiveRecord\Model
 {
+    private $name;
+
     public static $table = 'authors';
     public static $before_save = 'before_save';
 

--- a/test/CallbackTest.php
+++ b/test/CallbackTest.php
@@ -6,6 +6,8 @@ use test\models\VenueCB;
 
 class CallBackTest extends DatabaseTestCase
 {
+    private $callback;
+    
     public function setUp($connection_name=null): void
     {
         parent::setUp($connection_name);

--- a/test/ColumnTest.php
+++ b/test/ColumnTest.php
@@ -7,6 +7,9 @@ use PHPUnit\Framework\TestCase;
 
 class ColumnTest extends TestCase
 {
+    private $column;
+    private $conn;
+    
     public function setUp($connection_name = null): void
     {
         $this->column = new Column();

--- a/test/ConfigTest.php
+++ b/test/ConfigTest.php
@@ -143,6 +143,9 @@ class TestDateTime
 
 class ConfigTest extends TestCase
 {
+    private $config;
+    private $connections;
+
     public function setUp(): void
     {
         $this->config = new Config();

--- a/test/ConnectionManagerTest.php
+++ b/test/ConnectionManagerTest.php
@@ -19,9 +19,7 @@ class ConnectionManagerTest extends DatabaseTestCase
     public function test_get_connection_uses_existing_object()
     {
         $a = ConnectionManager::get_connection('mysql');
-        $a->harro = 'harro there';
-
-        $this->assertSame($a, ConnectionManager::get_connection('mysql'));
+        $this->assertSame($a === ConnectionManager::get_connection('mysql'), true);
     }
 
     public function test_gh_91_get_connection_with_null_connection_is_always_default()

--- a/test/DateTimeTest.php
+++ b/test/DateTimeTest.php
@@ -7,6 +7,9 @@ use test\models\Author;
 
 class DateTimeTest extends TestCase
 {
+    private $date;
+    private $original_format;
+
     public function setUp(): void
     {
         $this->date = new DateTime();

--- a/test/InflectorTest.php
+++ b/test/InflectorTest.php
@@ -6,6 +6,8 @@ require_once __DIR__ . '/../lib/Inflector.php';
 
 class InflectorTest extends TestCase
 {
+    private $inflector;
+
     public function setUp(): void
     {
         $this->inflector = ActiveRecord\Inflector::instance();

--- a/test/ModelCallbackTest.php
+++ b/test/ModelCallbackTest.php
@@ -4,6 +4,9 @@ use test\models\Venue;
 
 class ModelCallbackTest extends DatabaseTestCase
 {
+    private $callback;
+    private $venue;
+
     public function setUp($connection_name=null): void
     {
         parent::setUp($connection_name);

--- a/test/SQLBuilderTest.php
+++ b/test/SQLBuilderTest.php
@@ -7,6 +7,8 @@ use test\models\Author;
 
 class SQLBuilderTest extends DatabaseTestCase
 {
+    private $sql;
+
     protected $table_name = 'authors';
     protected $class_name = Author::class;
     protected $table;

--- a/test/UtilsTest.php
+++ b/test/UtilsTest.php
@@ -5,6 +5,9 @@ use PHPUnit\Framework\TestCase;
 
 class UtilsTest extends TestCase
 {
+    private $object_array;
+    private $array_hash;
+
     public function setUp(): void
     {
         $this->object_array = [null, null];


### PR DESCRIPTION
- Updated documentation to remove support for Oracle since the tests no longer test it
- Moved some developer-specific documentation from readme.md to contributing.md
- Fixed PHP 8.2 deprecation errors in running the tests
- Upgraded phpunit.xml.dist to remove deprecation warning