### PR TITLE
dynamic stan extension for Model::find

### DIFF
--- a/lib/Model.php
+++ b/lib/Model.php
@@ -1496,7 +1496,7 @@ class Model
      *
      * @throws ActiveRecordException
      *
-     * @return Model|int|Model[]|null
+     * @return mixed
      *
      * @see find
      */
@@ -1678,18 +1678,18 @@ class Model
      * Finding by using a conditions array:
      *
      * ```
-     * YourModel::find('first', array('conditions' => array('name=?','Tito'),
-     *   'order' => 'name asc'))
-     * YourModel::find('all', array('conditions' => 'amount > 3.14159265'));
-     * YourModel::find('all', array('conditions' => array('id in(?)', array(1,2,3))));
+     * YourModel::find('first', ['conditions' => ['name=?','Tito']],
+     *   'order' => 'name asc'])
+     * YourModel::find('all', ['conditions' => 'amount > 3.14159265']);
+     * YourModel::find('all', ['conditions' => ['id in(?)', [1,2,3]]]);
      * ```
      *
      * Finding by using a hash:
      *
      * ```
-     * YourModel::find(array('name' => 'Tito', 'id' => 1));
-     * YourModel::find('first',array('name' => 'Tito', 'id' => 1));
-     * YourModel::find('all',array('name' => 'Tito', 'id' => 1));
+     * YourModel::find(['name' => 'Tito', 'id' => 1]);
+     * YourModel::find('first',['name' => 'Tito', 'id' => 1]);
+     * YourModel::find('all',['name' => 'Tito', 'id' => 1]);
      * ```
      *
      * An options array can take the following parameters:

--- a/lib/Model.php
+++ b/lib/Model.php
@@ -1496,11 +1496,9 @@ class Model
      *
      * @throws ActiveRecordException
      *
-     * @return mixed
-     *
      * @see find
      */
-    public static function __callStatic(string $method, mixed $args)
+    public static function __callStatic(string $method, mixed $args): mixed
     {
         $options = static::extract_and_validate_options($args);
         $create = false;

--- a/lib/PhpStan/FindDynamicMethodReturnTypeReflection.php
+++ b/lib/PhpStan/FindDynamicMethodReturnTypeReflection.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace ActiveRecord\PhpStan;
+
+use ActiveRecord\Model;
+use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\StaticCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Type\ArrayType;
+use PHPStan\Type\Constant\ConstantArrayType;
+use PHPStan\Type\Constant\ConstantStringType;
+use PHPStan\Type\DynamicStaticMethodReturnTypeExtension;
+use PHPStan\Type\IntegerType;
+use PHPStan\Type\NullType;
+use PHPStan\Type\ObjectType;
+use PHPStan\Type\Type;
+use PHPStan\Type\UnionType;
+
+// DynamicStaticMethodReturnTypeExtension
+class FindDynamicMethodReturnTypeReflection implements DynamicStaticMethodReturnTypeExtension
+{
+    public function getClass(): string
+    {
+        return Model::class;
+    }
+
+    public function isStaticMethodSupported(MethodReflection $methodReflection): bool
+    {
+        return 'find' === $methodReflection->getName();
+    }
+
+    public function getTypeFromStaticMethodCall(MethodReflection $methodReflection, StaticCall $methodCall, Scope $scope): Type
+    {
+        $subclass = $methodCall->class . '';
+        $args = $methodCall->args;
+
+        $args = array_map(static function ($arg) use ($scope) {
+            $val = $arg->value;
+            assert($val instanceof Expr);
+
+            return $scope->getType($val);
+        }, $args);
+
+        $numArgs = count($args);
+        $single = false;
+        $nullable = false;
+
+        if (1 == $numArgs) {
+            if (!($args[0] instanceof ConstantArrayType)
+                || ('conditions' != $args[0]->getKeyTypes()[0]->getValue()
+                    && !$this->isNumericArray($args[0]))) {
+                $single = true;
+            }
+        } elseif ($numArgs > 1) {
+            if (($args[0] instanceof ConstantStringType) && (
+                'first' === $args[0]->getValue()
+                || 'last' === $args[0]->getValue()
+            )) {
+                $single = true;
+                $nullable = true;
+            }
+        }
+
+        if ($single && $nullable) {
+            return new UnionType([
+                new ObjectType($methodCall->class),
+                new NullType()
+            ]);
+        } elseif ($single) {
+            return new ObjectType($subclass);
+        }
+
+        return new ArrayType(new IntegerType(), new ObjectType($subclass));
+    }
+
+    protected function isNumericArray(ConstantArrayType $args): bool
+    {
+        $keys = $args->getKeyTypes();
+        $allInt = true;
+        foreach ($keys as $key) {
+            if (!($key instanceof IntegerType)) {
+                $allInt = false;
+                break;
+            }
+        }
+
+        return $allInt;
+    }
+}

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -3,9 +3,16 @@ parameters:
     tmpDir: .stan-cache
     paths:
         - %currentWorkingDirectory%/lib
+        - %currentWorkingDirectory%/test/phpstan
 
     reportUnmatchedIgnoredErrors: false
     ignoreErrors:
+
+services:
+    -
+        class: ActiveRecord\PhpStan\FindDynamicMethodReturnTypeReflection
+        tags:
+          - phpstan.broker.dynamicStaticMethodReturnTypeExtension
 
 includes:
 	- vendor/phpstan/phpstan-phpunit/extension.neon

--- a/test/ActiveRecordFindTest.php
+++ b/test/ActiveRecordFindTest.php
@@ -5,16 +5,10 @@ use ActiveRecord\Exception\DatabaseException;
 use ActiveRecord\Exception\RecordNotFound;
 use ActiveRecord\Exception\UndefinedPropertyException;
 use ActiveRecord\Model;
-use ActiveRecord\PhpStan\FindDynamicMethodReturnTypeReflection;
-use PHPStan\Command\AnalyseCommand;
-use shmax\Environment;
-use Symfony\Component\Console\Application;
-use Symfony\Component\Console\Command\Command;
 use test\models\Author;
 use test\models\HonestLawyer;
 use test\models\JoinBook;
 use test\models\Venue;
-use function PHPStan\dumpType;
 
 class ActiveRecordFindTest extends DatabaseTestCase
 {
@@ -22,43 +16,6 @@ class ActiveRecordFindTest extends DatabaseTestCase
     {
         $this->expectException(RecordNotFound::class);
         Author::find();
-    }
-
-    public function test_phpstan()
-    {
-        $res = dumpType(1);
-//        $version = "Version unknown";
-//        try {
-//            $version = \Jean85\PrettyVersions::getVersion(
-//                "phpstan/phpstan"
-//            )->getPrettyVersion();
-//        } catch (\OutOfBoundsException $e) {
-//        }
-//
-//        $application = new _PHPStan_a4fa95a42\Symfony\Component\Console\Application(
-//            "PHPStan - PHP Static Analysis Tool",
-//            $version
-//        );
-//        $application->setAutoExit(false);
-//        $application->add(new AnalyseCommand([]));
-//        //				$application->add(new DumpDependenciesCommand());
-//        try {
-//            $res = $application->run(
-//                new \_PHPStan_a4fa95a42\Symfony\Component\Console\Input\ArgvInput(
-//                    [
-//                        "vendor/phpstan/phpstan/bin/phpstan",
-//                        "analyse",
-//                        "--xdebug",
-//                        "--debug",
-//                        "-c",
-//                        "d:/repos/shmax/activerecord/phpstan.neon.dist",
-//                        "d:/repos/shmax/activerecord/test/phpstan/PhpStanReflectionTests.php",
-//                    ]
-//                )
-//            );
-//        } catch (\Throwable $e) {
-//            xdebug_break();
-//        }
     }
 
     public function test_find_returns_single_model() {

--- a/test/ActiveRecordFindTest.php
+++ b/test/ActiveRecordFindTest.php
@@ -5,10 +5,16 @@ use ActiveRecord\Exception\DatabaseException;
 use ActiveRecord\Exception\RecordNotFound;
 use ActiveRecord\Exception\UndefinedPropertyException;
 use ActiveRecord\Model;
+use ActiveRecord\PhpStan\FindDynamicMethodReturnTypeReflection;
+use PHPStan\Command\AnalyseCommand;
+use shmax\Environment;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Command\Command;
 use test\models\Author;
 use test\models\HonestLawyer;
 use test\models\JoinBook;
 use test\models\Venue;
+use function PHPStan\dumpType;
 
 class ActiveRecordFindTest extends DatabaseTestCase
 {
@@ -16,6 +22,43 @@ class ActiveRecordFindTest extends DatabaseTestCase
     {
         $this->expectException(RecordNotFound::class);
         Author::find();
+    }
+
+    public function test_phpstan()
+    {
+        $res = dumpType(1);
+//        $version = "Version unknown";
+//        try {
+//            $version = \Jean85\PrettyVersions::getVersion(
+//                "phpstan/phpstan"
+//            )->getPrettyVersion();
+//        } catch (\OutOfBoundsException $e) {
+//        }
+//
+//        $application = new _PHPStan_a4fa95a42\Symfony\Component\Console\Application(
+//            "PHPStan - PHP Static Analysis Tool",
+//            $version
+//        );
+//        $application->setAutoExit(false);
+//        $application->add(new AnalyseCommand([]));
+//        //				$application->add(new DumpDependenciesCommand());
+//        try {
+//            $res = $application->run(
+//                new \_PHPStan_a4fa95a42\Symfony\Component\Console\Input\ArgvInput(
+//                    [
+//                        "vendor/phpstan/phpstan/bin/phpstan",
+//                        "analyse",
+//                        "--xdebug",
+//                        "--debug",
+//                        "-c",
+//                        "d:/repos/shmax/activerecord/phpstan.neon.dist",
+//                        "d:/repos/shmax/activerecord/test/phpstan/PhpStanReflectionTests.php",
+//                    ]
+//                )
+//            );
+//        } catch (\Throwable $e) {
+//            xdebug_break();
+//        }
     }
 
     public function test_find_returns_single_model() {

--- a/test/phpstan/PhpStanReflectionTests.php
+++ b/test/phpstan/PhpStanReflectionTests.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * This file is not something we need to execute in tests. It's included
+ * only as a means to test and aid in the development of dynamic PHPStan
+ * extensions. If it doesn't emit any errors when you run 'composer stan',
+ * then everything is working fine.
+ *
+ * see lib/PhpStan/FindDynamicMethodReturnTypeReflection.php
+ */
+
+use test\models\Book;
+
+/**
+ * Static checking for single model
+ */
+$book = Book::find(1);
+assert($book instanceof Book);
+
+$book = Book::find(['name'=>'Ubik']);
+assert($book instanceof Book);
+
+/**
+ * Static checking for nullable single model
+ */
+$book = Book::find('first', ['name'=>'Waldo']);
+assert(is_null($book));
+
+$book = Book::find('last', ['name'=>'Waldo']);
+assert(is_null($book));
+
+/**
+ * Static checking for array of models
+ */
+$books = Book::find(
+    'all',
+    ['name' => 'William']
+);
+assert(0==count($books));
+
+$books = Book::find(1, 3, 8);
+assert(0==count($books));
+
+$books = Book::find([1, 3, 8]);
+assert(0==count($books));
+
+$books = Book::find(['conditions'=> ['name' => 'Kurt']]);
+assert(0==count($books));


### PR DESCRIPTION
Adding a PHPStan extension so that the various return types of `Model::find`  can be statically checked.

In other words, if you're a PHPStan user, the following snippets will now all pass analysis without errors:

```php
/**
 * Static checking for single model
 */
$book = Book::find(1);
assert($book instanceof Book);

$book = Book::find(['name'=>'Ubik']);
assert($book instanceof Book);

/**
 * Static checking for nullable single model
 */
$book = Book::find('first', ['name'=>'Waldo']);
assert(is_null($book));

$book = Book::find('last', ['name'=>'Waldo']);
assert(is_null($book));

/**
 * Static checking for array of models
 */
$books = Book::find(
    'all',
    ['name' => 'William']
);
assert(0==count($books));

$books = Book::find(1, 3, 8);
assert(0==count($books));

$books = Book::find([1, 3, 8]);
assert(0==count($books));

$books = Book::find(['conditions'=> ['name' => 'Kurt']]);
assert(0==count($books));
```

