### PR TITLE
static checking for count_by

### DIFF
--- a/lib/PhpStan/ModelMethodsClassReflectionExtension.php
+++ b/lib/PhpStan/ModelMethodsClassReflectionExtension.php
@@ -12,7 +12,11 @@ class ModelMethodsClassReflectionExtension implements MethodsClassReflectionExte
     public function hasMethod(ClassReflection $classReflection, string $methodName): bool
     {
         if ($classReflection->isSubclassOf(Model::class)) {
-            if (preg_match('/find_(all_)?by_/', $methodName)) {
+            if (preg_match('/\bfind_(all_)?by_/', $methodName)) {
+                return true;
+            }
+
+            if (preg_match('/\bcount_by_/', $methodName)) {
                 return true;
             }
 

--- a/lib/PhpStan/ModelStaticMethodReflection.php
+++ b/lib/PhpStan/ModelStaticMethodReflection.php
@@ -112,7 +112,7 @@ class ModelStaticMethodReflection implements MethodReflection
     public function getVariants(): array
     {
         if (str_starts_with($this->name, 'count_by')) {
-            $parts = SQLBuilder::underscored_string_to_parts(substr($this->name, 8), 0);
+            $parts = SQLBuilder::underscored_string_to_parts(substr($this->name, 9), 0);
 
             return [
                 new FunctionVariant(

--- a/lib/PhpStan/ModelStaticMethodReflection.php
+++ b/lib/PhpStan/ModelStaticMethodReflection.php
@@ -111,7 +111,19 @@ class ModelStaticMethodReflection implements MethodReflection
      */
     public function getVariants(): array
     {
-        if (str_starts_with($this->name, 'find_by')) {
+        if (str_starts_with($this->name, 'count_by')) {
+            $parts = SQLBuilder::underscored_string_to_parts(substr($this->name, 8), 0);
+
+            return [
+                new FunctionVariant(
+                    TemplateTypeMap::createEmpty(),
+                    TemplateTypeMap::createEmpty(),
+                    array_fill(0, count($parts), new ModelParameterReflection()),
+                    false,
+                    new IntegerType()
+                )
+            ];
+        } elseif (str_starts_with($this->name, 'find_by')) {
             $parts = SQLBuilder::underscored_string_to_parts(substr($this->name, 8), 0);
 
             return [

--- a/test/phpstan/DynamicCountBy.php
+++ b/test/phpstan/DynamicCountBy.php
@@ -10,8 +10,5 @@
 
 use test\models\Book;
 
-$book = Book::find_by_name('Walden');
-assert($book instanceof Book);
-
-$book = Book::find_by_name_and_publisher('Walden', 'Random House');
-assert(is_null($book));
+$numBooks = Book::count_by_name('Walden');
+assert(is_int($numBooks));


### PR DESCRIPTION
Static checking for `Model::count_by` magic method.

```php
use test\models\Book;

$numBooks = Book::count_by_name('Walden');
assert(is_int($numBooks));
```
...now passes static analysis.