### PR TITLE
clean up static delegate prop

### DIFF
--- a/lib/Model.php
+++ b/lib/Model.php
@@ -110,17 +110,15 @@ class Model
 {
     /**
      * An instance of {@link ValidationErrors} and will be instantiated once a write method is called.
-     *
-     * @var ValidationErrors
      */
-    public $errors;
+    public ValidationErrors $errors;
 
     /**
      * Contains model values as column_name => value
      *
      * @var Attributes
      */
-    private $attributes = [];
+    private array $attributes = [];
 
     /**
      * Flag whether this model's attributes have been modified since it will either be null or an array of column_names that have been modified
@@ -131,10 +129,8 @@ class Model
 
     /**
      * Flag that determines of this model can have a writer method invoked such as: save/update/insert/delete
-     *
-     * @var bool
      */
-    private $__readonly = false;
+    private bool $__readonly = false;
 
     /**
      * Array of relationship objects as model_attribute_name => relationship
@@ -295,10 +291,10 @@ class Model
      *      'venue' => true,
      *      'host' => true
      *  ];
-     *  static $delegate = array(
-     *     array('name', 'state', 'to' => 'venue'),
-     *     array('name', 'to' => 'host', 'prefix' => 'woot'));
-     * }
+     *  static $delegate = [
+     *     ['name', 'state', 'to' => 'venue'],
+     *     ['name', 'to' => 'host', 'prefix' => 'woot'];
+     * ]
      * ```
      *
      * Can then do:
@@ -312,7 +308,6 @@ class Model
      * @var array<DelegateOptions>
      */
     public static array $delegate = [];
-    protected static bool $delegateDirty = true;
 
     /**
      * Constructs a model.
@@ -815,7 +810,7 @@ class Model
                 $name = substr($name, strlen($delegate['prefix']) + 1);
             }
 
-            if (in_array($name, $delegate['delegate'] ?? [])) {
+            if (in_array($name, $delegate['delegate'])) {
                 return $name;
             }
         }

--- a/lib/Model.php
+++ b/lib/Model.php
@@ -292,8 +292,20 @@ class Model
      *      'host' => true
      *  ];
      *  static $delegate = [
-     *     ['name', 'state', 'to' => 'venue'],
-     *     ['name', 'to' => 'host', 'prefix' => 'woot'];
+     *    [
+     *      'attributes' => [
+     *        'name',
+     *        'state'
+     *      ],
+     *      'to' => 'venue'
+     *    ],
+     *    [
+     *      'attributes' => [
+     *        'name'
+     *      ],
+     *      'to' => 'host',
+     *      'prefix' => 'woot'
+     *   ];
      * ]
      * ```
      *

--- a/lib/Model.php
+++ b/lib/Model.php
@@ -312,6 +312,7 @@ class Model
      * @var array<DelegateOptions>
      */
     public static array $delegate = [];
+    protected static bool $delegateDirty = true;
 
     /**
      * Constructs a model.

--- a/lib/Table.php
+++ b/lib/Table.php
@@ -625,11 +625,10 @@ class Table
     private function set_delegates(): void
     {
         $delegates = $this->class->getStaticPropertyValue('delegate', []);
+        $delegateDirty = $this->class->getStaticPropertyValue('delegateDirty', []);
         $new = [];
 
-        $delegates['processed'] ??= false;
-
-        if (!empty($delegates) && !$delegates['processed']) {
+        if (!empty($delegates) && $delegateDirty) {
             foreach ($delegates as &$delegate) {
                 if (!is_array($delegate) || !isset($delegate['to'])) {
                     continue;
@@ -653,7 +652,7 @@ class Table
                 $new[] = $new_delegate;
             }
 
-            $new['processed'] = true;
+            $this->class->setStaticPropertyValue('delegateDirty', false);
             $this->class->setStaticPropertyValue('delegate', $new);
         }
     }

--- a/lib/Table.php
+++ b/lib/Table.php
@@ -120,7 +120,6 @@ class Table
         $this->get_meta_data();
         $this->set_primary_key();
         $this->set_sequence_name();
-        $this->set_delegates();
         $this->set_cache();
 
         $this->callback = new CallBack($class_name);
@@ -611,49 +610,6 @@ class Table
                     $this->add_relationship($relationship);
                 }
             }
-        }
-    }
-
-    /**
-     * Rebuild the delegates array into format that we can more easily work with in Model.
-     * Will end up consisting of array of:
-     *
-     * array('delegate' => array('field1','field2',...),
-     *       'to'       => 'delegate_to_relationship',
-     *       'prefix'	=> 'prefix')
-     */
-    private function set_delegates(): void
-    {
-        $delegates = $this->class->getStaticPropertyValue('delegate', []);
-        $delegateDirty = $this->class->getStaticPropertyValue('delegateDirty', []);
-        $new = [];
-
-        if (!empty($delegates) && $delegateDirty) {
-            foreach ($delegates as &$delegate) {
-                if (!is_array($delegate) || !isset($delegate['to'])) {
-                    continue;
-                }
-
-                if (!isset($delegate['prefix'])) {
-                    $delegate['prefix'] = null;
-                }
-
-                $new_delegate = [
-                    'to'        => $delegate['to'],
-                    'prefix'    => $delegate['prefix'],
-                    'delegate'    => []];
-
-                foreach ($delegate as $name => $value) {
-                    if (is_numeric($name)) {
-                        $new_delegate['delegate'][] = $value;
-                    }
-                }
-
-                $new[] = $new_delegate;
-            }
-
-            $this->class->setStaticPropertyValue('delegateDirty', false);
-            $this->class->setStaticPropertyValue('delegate', $new);
         }
     }
 }

--- a/lib/Types.php
+++ b/lib/Types.php
@@ -28,7 +28,7 @@ namespace ActiveRecord;
  * @phpstan-type DelegateOptions array{
  *  to: string,
  *  prefix?: string,
- *  delegate?: array<string>
+ *  delegate: array<string>
  * }
  */
 abstract class Types

--- a/test/ActiveRecordTest.php
+++ b/test/ActiveRecordTest.php
@@ -377,54 +377,6 @@ class ActiveRecordTest extends DatabaseTestCase
         $this->assertEquals($original, Author::count());
     }
 
-    public function testDelegate()
-    {
-        $event = Event::first();
-        $this->assertEquals($event->venue->state, $event->state);
-        $this->assertEquals($event->venue->address, $event->address);
-    }
-
-    public function testDelegatePrefix()
-    {
-        $event = Event::first();
-        $this->assertEquals($event->host->name, $event->woot_name);
-    }
-
-    public function testDelegateReturnsNullIfRelationshipDoesNotExist()
-    {
-        $event = new Event();
-        $this->assertNull($event->state);
-    }
-
-    public function testDelegateSetAttribute()
-    {
-        $event = Event::first();
-        $event->state = 'MEXICO';
-        $this->assertEquals('MEXICO', $event->venue->state);
-    }
-
-    public function testDelegateGetterGh98()
-    {
-        Venue::$use_custom_get_state_getter = true;
-
-        $event = Event::first();
-        $this->assertEquals('ny', $event->venue->state);
-        $this->assertEquals('ny', $event->state);
-
-        Venue::$use_custom_get_state_getter = false;
-    }
-
-    public function testDelegateSetterGh98()
-    {
-        Venue::$use_custom_set_state_setter = true;
-
-        $event = Event::first();
-        $event->state = 'MEXICO';
-        $this->assertEquals('MEXICO#', $event->venue->state);
-
-        Venue::$use_custom_set_state_setter = false;
-    }
-
     public function testTableNameWithUnderscores()
     {
         $this->assertNotNull(AwesomePerson::first());

--- a/test/DelegateTest.php
+++ b/test/DelegateTest.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace test;
+
+use ActiveRecord;
+use ActiveRecord\Exception\ActiveRecordException;
+use ActiveRecord\Exception\ReadOnlyException;
+use ActiveRecord\Exception\UndefinedPropertyException;
+use DatabaseTestCase;
+use test\models\Author;
+use test\models\AwesomePerson;
+use test\models\Book;
+use test\models\BookAttrAccessible;
+use test\models\Event;
+use test\models\RmBldg;
+use test\models\Venue;
+
+class DelegateTest extends DatabaseTestCase
+{
+    private $options;
+
+    public function setUp($connection_name = null): void
+    {
+        parent::setUp($connection_name);
+        $this->options = ['conditions' => 'blah', 'order' => 'blah'];
+    }
+
+
+    public function testOptionsHashWithUnknownKeys()
+    {
+        $this->expectException(ActiveRecordException::class);
+        $this->assertFalse(Author::is_options_hash(['conditions' => 'blah', 'sharks' => 'laserz', 'dubya' => 'bush']));
+    }
+
+    public function testDelegate()
+    {
+        $event = Event::first();
+        $this->assertEquals($event->venue->state, $event->state);
+        $this->assertEquals($event->venue->address, $event->address);
+    }
+
+    public function testDelegatePrefix()
+    {
+        $event = Event::first();
+        $this->assertEquals($event->host->name, $event->woot_name);
+    }
+
+    public function testDelegateReturnsNullIfRelationshipDoesNotExist()
+    {
+        $event = new Event();
+        $this->assertNull($event->state);
+    }
+
+    public function testDelegateSetAttribute()
+    {
+        $event = Event::first();
+        $event->state = 'MEXICO';
+        $this->assertEquals('MEXICO', $event->venue->state);
+    }
+
+    public function testDelegateGetterGh98()
+    {
+        Venue::$use_custom_get_state_getter = true;
+
+        $event = Event::first();
+        $this->assertEquals('ny', $event->venue->state);
+        $this->assertEquals('ny', $event->state);
+
+        Venue::$use_custom_get_state_getter = false;
+    }
+
+    public function testDelegateSetterGh98()
+    {
+        Venue::$use_custom_set_state_setter = true;
+
+        $event = Event::first();
+        $event->state = 'MEXICO';
+        $this->assertEquals('MEXICO#', $event->venue->state);
+
+        Venue::$use_custom_set_state_setter = false;
+    }
+}

--- a/test/DelegateTest.php
+++ b/test/DelegateTest.php
@@ -2,20 +2,12 @@
 
 namespace test;
 
-use ActiveRecord;
 use ActiveRecord\Exception\ActiveRecordException;
-use ActiveRecord\Exception\ReadOnlyException;
-use ActiveRecord\Exception\UndefinedPropertyException;
-use DatabaseTestCase;
 use test\models\Author;
-use test\models\AwesomePerson;
-use test\models\Book;
-use test\models\BookAttrAccessible;
 use test\models\Event;
-use test\models\RmBldg;
 use test\models\Venue;
 
-class DelegateTest extends DatabaseTestCase
+class DelegateTest extends \DatabaseTestCase
 {
     private $options;
 
@@ -24,7 +16,6 @@ class DelegateTest extends DatabaseTestCase
         parent::setUp($connection_name);
         $this->options = ['conditions' => 'blah', 'order' => 'blah'];
     }
-
 
     public function testOptionsHashWithUnknownKeys()
     {

--- a/test/models/Event.php
+++ b/test/models/Event.php
@@ -12,7 +12,19 @@ class Event extends Model
     ];
 
     public static array $delegate = [
-        ['state', 'address', 'to' => 'venue'],
-        ['name', 'to' => 'host', 'prefix' => 'woot']
+        [
+            'delegate'=>[
+                'state',
+                'address'
+            ],
+            'to' => 'venue'
+        ],
+        [
+            'delegate'=>[
+                'name'
+            ],
+            'to' => 'host',
+            'prefix' => 'woot'
+        ]
     ];
 }

--- a/test/phpstan/DynamicFInd.php
+++ b/test/phpstan/DynamicFInd.php
@@ -9,6 +9,7 @@
  */
 
 use test\models\Book;
+use function PHPStan\dumpType;
 
 /**
  * Static checking for single model

--- a/test/phpstan/DynamicFInd.php
+++ b/test/phpstan/DynamicFInd.php
@@ -9,7 +9,6 @@
  */
 
 use test\models\Book;
-use function PHPStan\dumpType;
 
 /**
  * Static checking for single model


### PR DESCRIPTION
Fix for: https://github.com/php-activerecord/activerecord/issues/51

It turns out that all the delegate processing stuff in `Table` was just transforming the mixed array structure into one that is easier to read and deal with, so I just adopted the prettier structure as the formal API shape, and then I was able to kill off that section of code and make the configuration statically checkable in the same step. That also killed the need for the `processed` flag.