### PR TITLE
Start on HasAndBelongsToMany

### DIFF
--- a/lib/Model.php
+++ b/lib/Model.php
@@ -83,6 +83,7 @@ use ActiveRecord\Serialize\Serialization;
  * please consult our {@link http://www.phpactiverecord.org/guides Guides}.
  *
  * @phpstan-import-type HasManyOptions from Types
+ * @phpstan-import-type HasAndBelongsToManyOptions from Types
  * @phpstan-import-type BelongsToOptions from Types
  * @phpstan-import-type SerializeOptions from Serialize\Serialization
  * @phpstan-import-type ValidationOptions from Validations
@@ -224,6 +225,11 @@ class Model
      * @var array<string,HasManyOptions>
      */
     public static array $has_many;
+
+    /**
+     * @var array<string, HasAndBelongsToManyOptions>
+     */
+    public static array $has_and_belongs_to_many;
 
     /**
      * @var array<string,HasManyOptions>

--- a/lib/Relationship/AbstractRelationship.php
+++ b/lib/Relationship/AbstractRelationship.php
@@ -220,7 +220,7 @@ abstract class AbstractRelationship
         $class_name = $this->class_name;
 
         $model = new $class_name($attributes, $guard_attributes);
-        assert($model instanceof $class_name);
+        assert($model instanceof Model);
 
         return $model;
     }

--- a/lib/Relationship/AbstractRelationship.php
+++ b/lib/Relationship/AbstractRelationship.php
@@ -58,10 +58,12 @@ abstract class AbstractRelationship
      * @var array<string>
      */
     protected static $valid_association_options = [
+        'association_foreign_key',
         'class_name',
         'foreign_key',
         'conditions',
         'select',
+        'join_table',
         'readonly',
         'namespace'
     ];

--- a/lib/Relationship/AbstractRelationship.php
+++ b/lib/Relationship/AbstractRelationship.php
@@ -220,7 +220,7 @@ abstract class AbstractRelationship
         $class_name = $this->class_name;
 
         $model = new $class_name($attributes, $guard_attributes);
-        assert($model instanceof Model);
+        assert($model instanceof $class_name);
 
         return $model;
     }

--- a/lib/Relationship/AbstractRelationship.php
+++ b/lib/Relationship/AbstractRelationship.php
@@ -339,7 +339,7 @@ abstract class AbstractRelationship
      *
      * @return string SQL INNER JOIN fragment
      */
-    public function construct_inner_join_sql(Table $from_table, $using_through = false, $alias = null)
+    public function construct_inner_join_sql(Table $from_table, bool $using_through = false, string $alias = null)
     {
         if ($using_through) {
             $join_table_name = $from_table->get_fully_qualified_table_name();

--- a/lib/Relationship/HasAndBelongsToMany.php
+++ b/lib/Relationship/HasAndBelongsToMany.php
@@ -12,12 +12,10 @@ use ActiveRecord\Types;
  * @package ActiveRecord
  *
  * @phpstan-import-type HasAndBelongsToManyOptions from Types
- *
  */
 class HasAndBelongsToMany extends AbstractRelationship
 {
     /**
-     * @param string $attribute
      * @param HasAndBelongsToManyOptions $options
      */
     public function __construct(string $attribute, array $options = [])

--- a/lib/Relationship/HasAndBelongsToMany.php
+++ b/lib/Relationship/HasAndBelongsToMany.php
@@ -2,25 +2,34 @@
 
 namespace ActiveRecord\Relationship;
 
+use ActiveRecord\Inflector;
 use ActiveRecord\Model;
+use ActiveRecord\Relation;
 use ActiveRecord\Table;
 use ActiveRecord\Types;
+use ActiveRecord\Utils;
 
 /**
  * @todo implement me
  *
- * @package ActiveRecord
+ * @template TModel of Model
  *
  * @phpstan-import-type HasAndBelongsToManyOptions from Types
  */
 class HasAndBelongsToMany extends AbstractRelationship
 {
+    protected string $association_foreign_key = '';
+
     /**
      * @param HasAndBelongsToManyOptions $options
      */
     public function __construct(string $attribute, array $options = [])
     {
         parent::__construct($attribute, $options);
+
+        $this->set_class_name($this->inferred_class_name(Utils::singularize($attribute)));
+
+        $this->options['association_foreign_key'] ??= Inflector::keyify($this->class_name);
     }
 
     public function is_poly(): bool
@@ -28,9 +37,43 @@ class HasAndBelongsToMany extends AbstractRelationship
         return true;
     }
 
+    /**
+     * @return array<TModel>
+     */
     public function load(Model $model): mixed
     {
-        throw new \Exception("HasAndBelongsToMany doesn't need to load anything.");
+        /**
+         * @var Relation<TModel>
+         */
+        $rel = new Relation($this->class_name, [], []);
+        $rel->from($this->attribute_name);
+        $other_table = $model->table()->table;
+        $rel->where($other_table . '. ' . $this->options['foreign_key'] . ' = ?', $model->{$model->get_primary_key()});
+        $rel->joins([$other_table]);
+
+        return $rel->to_a();
+    }
+
+    public static function inferJoiningTableName(string $class_name, string $association_name): string
+    {
+        $parts = [$association_name, $class_name];
+        sort($parts);
+
+        return implode('_', $parts);
+    }
+
+    public function construct_inner_join_sql(Table $from_table, bool $using_through = false, string $alias = null): string
+    {
+        $other_table = Table::load($this->class_name);
+        $associated_table_name = $other_table->table;
+        $from_table_name = $from_table->table;
+        $foreign_key = $this->options['foreign_key'];
+        $join_primary_key = $this->options['association_foreign_key'];
+        $linkingTableName = $this->options['join_table'];
+        $res = 'INNER JOIN ' . $linkingTableName . " ON ($from_table_name.$foreign_key = " . $linkingTableName . ".$foreign_key) "
+            . 'INNER JOIN ' . $associated_table_name . ' ON ' . $associated_table_name . '.' . $join_primary_key . ' = ' . $linkingTableName . '.' . $join_primary_key;
+
+        return $res;
     }
 
     public function load_eagerly($models, $attributes, $includes, Table $table): void

--- a/lib/Relationship/HasAndBelongsToMany.php
+++ b/lib/Relationship/HasAndBelongsToMany.php
@@ -20,13 +20,6 @@ class HasAndBelongsToMany extends AbstractRelationship
      */
     public function __construct(string $attribute, array $options = [])
     {
-        /* options =>
-         *   join_table - name of the join table if not in lexical order
-         *   foreign_key -
-         *   association_foreign_key - default is {assoc_class}_id
-         *   uniq - if true duplicate assoc objects will be ignored
-         *   validate
-         */
         parent::__construct($attribute, $options);
     }
 

--- a/lib/Relationship/HasAndBelongsToMany.php
+++ b/lib/Relationship/HasAndBelongsToMany.php
@@ -4,17 +4,24 @@ namespace ActiveRecord\Relationship;
 
 use ActiveRecord\Model;
 use ActiveRecord\Table;
+use ActiveRecord\Types;
 
 /**
  * @todo implement me
  *
  * @package ActiveRecord
  *
+ * @phpstan-import-type HasAndBelongsToManyOptions from Types
+ *
  * @see http://www.phpactiverecord.org/guides/associations
  */
 class HasAndBelongsToMany extends AbstractRelationship
 {
-    public function __construct($options = [])
+    /**
+     * @param string $attribute
+     * @param HasAndBelongsToManyOptions $options
+     */
+    public function __construct(string $attribute, array $options = [])
     {
         /* options =>
          *   join_table - name of the join table if not in lexical order
@@ -23,7 +30,7 @@ class HasAndBelongsToMany extends AbstractRelationship
          *   uniq - if true duplicate assoc objects will be ignored
          *   validate
          */
-        parent::__construct($options[0], $options);
+        parent::__construct($attribute, $options);
     }
 
     public function is_poly(): bool

--- a/lib/Relationship/HasAndBelongsToMany.php
+++ b/lib/Relationship/HasAndBelongsToMany.php
@@ -13,7 +13,6 @@ use ActiveRecord\Types;
  *
  * @phpstan-import-type HasAndBelongsToManyOptions from Types
  *
- * @see http://www.phpactiverecord.org/guides/associations
  */
 class HasAndBelongsToMany extends AbstractRelationship
 {

--- a/lib/Table.php
+++ b/lib/Table.php
@@ -582,7 +582,7 @@ class Table
                         break;
 
                     case 'has_and_belongs_to_many':
-                        $relationship = new HasAndBelongsToMany($definition);
+                        $relationship = new HasAndBelongsToMany($attribute, $definition);
                         break;
                 }
 

--- a/lib/Table.php
+++ b/lib/Table.php
@@ -582,6 +582,8 @@ class Table
                         break;
 
                     case 'has_and_belongs_to_many':
+                        $definition['join_table'] ??= HasAndBelongsToMany::inferJoiningTableName($this->table, $attribute);
+                        $definition['foreign_key'] ??= $this->pk[0];
                         $relationship = new HasAndBelongsToMany($attribute, $definition);
                         break;
                 }

--- a/lib/Types.php
+++ b/lib/Types.php
@@ -19,6 +19,14 @@ namespace ActiveRecord;
  *  order?: string,
  *  through?: string
  * }
+ * @phpstan-type HasAndBelongsToManyOptions array{
+ *  join_table?: string,
+ *  foreign_key?: string,
+ *  association_foreign_key?: string,
+ *  uniq?: bool,
+ *  validate?: bool
+ * }
+
  * @phpstan-type BelongsToOptions array{
  *  conditions?: array<mixed>,
  *  foreign_key?: string,

--- a/lib/Types.php
+++ b/lib/Types.php
@@ -12,11 +12,11 @@ namespace ActiveRecord;
  *  set?: string|array<string, mixed>
  * }
  * @phpstan-type HasManyOptions array{
+ *  group?: string,
  *  limit?: int,
  *  offset?: int,
- *  primary_key?: string|array<string>,
- *  group?: string,
  *  order?: string,
+ *  primary_key?: string|array<string>,
  *  through?: string
  * }
  * @phpstan-type HasAndBelongsToManyOptions array{

--- a/lib/Types.php
+++ b/lib/Types.php
@@ -26,7 +26,6 @@ namespace ActiveRecord;
  *  uniq?: bool,
  *  validate?: bool
  * }
-
  * @phpstan-type BelongsToOptions array{
  *  conditions?: array<mixed>,
  *  foreign_key?: string,

--- a/test/RelationshipTest.php
+++ b/test/RelationshipTest.php
@@ -15,7 +15,6 @@ use test\models\Host;
 use test\models\JoinBook;
 use test\models\Position;
 use test\models\Property;
-use test\models\Student;
 use test\models\Venue;
 
 class NotModel

--- a/test/RelationshipTest.php
+++ b/test/RelationshipTest.php
@@ -9,12 +9,14 @@ use test\models\Author;
 use test\models\AuthorAttrAccessible;
 use test\models\AwesomePerson;
 use test\models\Book;
+use test\models\Course;
 use test\models\Employee;
 use test\models\Event;
 use test\models\Host;
 use test\models\JoinBook;
 use test\models\Position;
 use test\models\Property;
+use test\models\Student;
 use test\models\Venue;
 
 class NotModel
@@ -264,7 +266,13 @@ class RelationshipTest extends DatabaseTestCase
 
     public function testHasAndBelongsToMany()
     {
-        $this->expectNotToPerformAssertions();
+        $student = Student::find(1);
+        $courses = $student->courses;
+        $this->assertEquals(2, count($courses));
+
+        $course = Course::find(3);
+        $students = $course->students;
+        $this->assertEquals(1, count($students));
     }
 
     public function testBelongsToCreateAssociation()

--- a/test/fixtures/courses.csv
+++ b/test/fixtures/courses.csv
@@ -1,0 +1,4 @@
+course_id,title
+1,"Gardening 101"
+2,"Advanced Calculus"
+3,"Bonehead Math"

--- a/test/fixtures/courses_students.csv
+++ b/test/fixtures/courses_students.csv
@@ -1,0 +1,6 @@
+student_id, course_id
+1,1
+1,2
+2,2
+2,3
+3,1

--- a/test/fixtures/students.csv
+++ b/test/fixtures/students.csv
@@ -1,0 +1,4 @@
+student_id,first_name
+1,"Ed"
+2,"Edd"
+3,"Eddy"

--- a/test/models/Course.php
+++ b/test/models/Course.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace test\models;
+
+use ActiveRecord\Model;
+
+class Course extends Model
+{
+    public static $pk = 'course_id';
+    public static array $has_and_belongs_to_many = [
+        'students' => []
+    ];
+}

--- a/test/models/Student.php
+++ b/test/models/Student.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace test\models;
+
+use ActiveRecord\Model;
+
+class Student extends Model
+{
+    public static $pk = 'student_id';
+    public static array $has_and_belongs_to_many = [
+        'courses'=>[]
+    ];
+}

--- a/test/sql/mysql.sql
+++ b/test/sql/mysql.sql
@@ -116,3 +116,19 @@ CREATE TABLE valuestore (
   `key` varchar(20) NOT NULL DEFAULT '',
   `value` varchar(255) NOT NULL DEFAULT ''
 ) ENGINE=InnoDB;
+
+CREATE TABLE students (
+  student_id INT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+  first_name VARCHAR(255) NOT NULL
+) ENGINE=InnoDB;
+
+CREATE TABLE courses (
+  course_id INT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+  title VARCHAR(255) NOT NULL
+) ENGINE=InnoDB;
+
+CREATE TABLE courses_students(
+  `course_id` int(11) NOT NULL DEFAULT '0',
+  `student_id` int(11) NOT NULL DEFAULT '0',
+  PRIMARY KEY(course_id, student_id)
+);

--- a/test/sql/pgsql.sql
+++ b/test/sql/pgsql.sql
@@ -116,5 +116,21 @@ CREATE TABLE valuestore (
   value varchar(255) NOT NULL DEFAULT ''
 );
 
+CREATE TABLE students (
+  student_id serial primary key,
+  first_name varchar(255) NOT NULL
+);
+
+CREATE TABLE courses (
+  course_id serial primary key,
+  title varchar(255) NOT NULL
+);
+
+CREATE TABLE courses_students(
+  course_id int not null,
+  student_id int not null,
+  PRIMARY KEY(course_id, student_id)
+);
+
 -- reproduces issue GH-96 for testing
 CREATE INDEX user_newsletters_id_and_user_id_idx ON user_newsletters USING btree(id, user_id);

--- a/test/sql/sqlite.sql
+++ b/test/sql/sqlite.sql
@@ -115,3 +115,19 @@ CREATE TABLE valuestore (
   `key` varchar(20) NOT NULL DEFAULT '',
   `value` varchar(255) NOT NULL DEFAULT ''
 );
+
+CREATE TABLE students (
+    student_id INTEGER NOT NULL PRIMARY KEY,
+    first_name varchar(255) NOT NULL DEFAULT ''
+);
+
+CREATE TABLE courses (
+     course_id INTEGER NOT NULL PRIMARY KEY,
+     title varchar(255) NOT NULL DEFAULT ''
+);
+
+CREATE TABLE courses_students(
+     course_id int not null,
+     student_id int not null,
+     PRIMARY KEY(course_id, student_id)
+);


### PR DESCRIPTION
An attempt at implementing `HasAndBelongsToMany` (which was marked with "TODO: implement" in the original code, and evidently never completed) functionality:

* create new Student and Courses fixtures (every student attends many courses, every course is attended by many students)
* remove `get_relationship` stuff from `RelationshipTest` (a horrible anti-pattern, IMO)
* create `HasManyAndBelongsToMany` type, and convert to a `array<string, HasManyAndBelongsToMany>` format (for easier static checking)

Note that this is just the read part of this; I'm not sure what to do about writes, because as far as I can tell none of the other relationship classes currently support writes (ie `build` and `create` don't actually create new records).