### PR TITLE
Optimize pluck, simplify stuff

### DIFF
--- a/lib/Connection.php
+++ b/lib/Connection.php
@@ -391,15 +391,15 @@ abstract class Connection
     /**
      * Execute a raw SQL query and fetch the results.
      *
-     * @param string   $sql     raw SQL string to execute
-     * @param \Closure $handler closure that will be passed the fetched results
+     * @param string       $sql    raw SQL string to execute
+     * @param array<mixed> $values
      */
-    public function query_and_fetch(string $sql, \Closure $handler): void
+    public function query_and_fetch(string $sql, array $values = [], int $method = \PDO::FETCH_ASSOC): \Generator
     {
-        $sth = $this->query($sql);
+        $sth = $this->query($sql, $values);
 
-        while ($row = $sth->fetch(\PDO::FETCH_ASSOC)) {
-            $handler($row);
+        while ($row = $sth->fetch($method)) {
+            yield $row;
         }
     }
 

--- a/lib/Model.php
+++ b/lib/Model.php
@@ -1602,6 +1602,16 @@ class Model
     /**
      * @return Relation<static>
      *
+     *@see Relation::distinct()
+     */
+    public static function distinct(bool $distinct = true): Relation
+    {
+        return static::Relation()->distinct($distinct);
+    }
+
+    /**
+     * @return Relation<static>
+     *
      *@see Relation::reselect()
      */
     public static function reselect(): Relation

--- a/lib/Relation.php
+++ b/lib/Relation.php
@@ -146,7 +146,9 @@ class Relation implements \Iterator
         $options = array_merge($this->options, ['select' => [static::toSingleArg(...$args)]]);
         $table = $this->table();
         $sql = $table->options_to_sql($options);
-        $retValue = iterator_to_array($table->conn->query_and_fetch($sql->to_s(), $sql->get_where_values(), \PDO::FETCH_NUM));
+        $retValue = iterator_to_array(
+            $table->conn->query_and_fetch($sql->to_s(), $sql->get_where_values(), \PDO::FETCH_NUM)
+        );
 
         return array_map(static function ($row) {
             return 1 == count($row) ? $row[0] : $row;
@@ -535,6 +537,24 @@ class Relation implements \Iterator
     public function readonly(bool $readonly): Relation
     {
         $this->options['readonly'] = $readonly;
+
+        return $this;
+    }
+
+    /**
+     * Specifies whether the records should be unique or not. For example:
+     *
+     * User::select('name') // Might return two records with the same name
+     *
+     * User::select('name')->distinct() // Returns 1 record per distinct name
+     *
+     * User::select('name')->distinct()->distinct(false) // You can also remove the uniqueness
+     *
+     * @return Relation<TModel>
+     */
+    public function distinct(bool $distinct=true): Relation
+    {
+        $this->options['distinct'] = $distinct;
 
         return $this;
     }

--- a/lib/Relation.php
+++ b/lib/Relation.php
@@ -107,12 +107,32 @@ class Relation implements \Iterator
     }
 
     /**
-     * Plucks the columns from the table, returning an column_value[] rather than a Model[]
+     * Use pluck as a shortcut to select one or more attributes without
+     * loading an entire record object per row.
      *
-     * $this->where(['name' => 'Bill'])->pluck('id') // returns [1]
-     * $this->where(['age' => 42])->pluck('id', 'name') // returns [[1, "David"], [2, "Fran"], [3, "Jose"]]
-     * $this->where(['age' => 42])->pluck('id, name') // returns [[1, "David"], [2, "Fran"], [3, "Jose"]]
-     * $this->where(['age' => 42])->pluck(['id', 'name']) // returns [[1, "David"], [2, "Fran"], [3, "Jose"]]
+     * $names = Person::pluck('name');
+     *
+     * instead of
+     *
+     * $names = array_map(fn($person) =>$person->name, Person::all()->to_a());
+     *
+     * Pluck returns an Array of attribute values type-casted to match
+     * the plucked column names, if they can be deduced.
+     *
+     * Person::pluck('name')                // SELECT people.name FROM people
+     *  => ['David', 'Jeremy', 'Jose']
+     *
+     * Person::pluck('id', 'name');         // SELECT people.id, people.name FROM people
+     *  => [[1, 'David'], [2, 'Jeremy'], [3, 'Jose']]
+     *
+     * Person::distinct()->pluck('role');   // SELECT DISTINCT role FROM people
+     *  => ['admin', 'member', 'guest']
+     *
+     * Person::where(['age' => 21])         // SELECT people.id FROM people WHERE people.age = 21 LIMIT 5
+     *  ->limit(5).pluck('id')
+     * => [2, 3]
+     *
+     * @see Relation::ids()
      *
      * @return array<mixed>
      */

--- a/lib/SQLBuilder.php
+++ b/lib/SQLBuilder.php
@@ -18,6 +18,8 @@ class SQLBuilder
 {
     private Connection $connection;
     private string $operation = 'SELECT';
+
+    private bool $distinct = false;
     private string $table;
     private string $select = '*';
 
@@ -175,8 +177,9 @@ class SQLBuilder
         return $this;
     }
 
-    public function select(string $select): static
+    public function select(string $select, bool $distinct = false): static
     {
+        $this->distinct = $distinct;
         $this->operation = 'SELECT';
         $this->select = $select;
 
@@ -344,7 +347,7 @@ class SQLBuilder
 
     private function build_select(): string
     {
-        $sql = "SELECT $this->select FROM $this->table";
+        $sql = 'SELECT ' . ($this->distinct ? 'DISTINCT ' : '') . "$this->select FROM $this->table";
 
         if (!empty($this->joins)) {
             $sql .= ' ' . $this->joins;

--- a/lib/Table.php
+++ b/lib/Table.php
@@ -223,7 +223,10 @@ class Table
                 $tokens = array_merge($tokens, array_map('trim', explode(',', $select)));
             }
 
-            $sql->select(array_search('*', $tokens) ? '*' : implode(', ', array_unique($tokens)));
+            $sql->select(
+                array_search('*', $tokens) ? '*' : implode(', ', array_unique($tokens)),
+                !empty($options['distinct'])
+            );
         }
 
         $sql->where($options['conditions'] ?? [], $options['mapped_names'] ?? []);

--- a/lib/Types.php
+++ b/lib/Types.php
@@ -42,6 +42,7 @@ namespace ActiveRecord;
  *  offset?: int,
  *  order?: string,
  *  readonly?: bool,
+ *  distinct?: bool,
  *  select?: string|array<string>,
  * }
  */

--- a/test/ActiveRecordCountTest.php
+++ b/test/ActiveRecordCountTest.php
@@ -9,7 +9,7 @@ class ActiveRecordCountTest extends \DatabaseTestCase
 {
     public function testNoArguments()
     {
-        $this->assertEquals(4, Author::count());
+        $this->assertEquals(5, Author::count());
     }
 
     public function testColumnNameAsArgument()

--- a/test/ActiveRecordFindTest.php
+++ b/test/ActiveRecordFindTest.php
@@ -234,8 +234,8 @@ class ActiveRecordFindTest extends DatabaseTestCase
     public function testFindLast()
     {
         $author = Author::last();
-        $this->assertEquals(4, $author->author_id);
-        $this->assertEquals('Uncle Bob', $author->name);
+        $this->assertEquals(5, $author->author_id);
+        $this->assertEquals('Tito', $author->name);
     }
 
     public function testFindLastUsingStringCondition()
@@ -316,7 +316,7 @@ class ActiveRecordFindTest extends DatabaseTestCase
     {
         $this->assertNotNull(Author::where(['name' => 'Tito'])->first());
         $this->assertNull(Author::where(['name' => 'Mortimer'])->first());
-        $this->assertEquals(1, count(Author::where(['name' => 'Tito'])->to_a()));
+        $this->assertEquals(2, count(Author::where(['name' => 'Tito'])->to_a()));
     }
 
     public function testFindOrCreateByOnExistingRecord()

--- a/test/ActiveRecordPluckTest.php
+++ b/test/ActiveRecordPluckTest.php
@@ -17,15 +17,29 @@ class ActiveRecordPluckTest extends \DatabaseTestCase
     public function testSingleArgument()
     {
         $authors = Author::pluck('name');
+        $this->assertEquals(5, count($authors));
+        $this->assertEquals('Tito', $authors[0]);
+        $this->assertEquals('George W. Bush', $authors[1]);
+    }
+
+    public function testSingleArgumentWithDistinct()
+    {
+        $authors = Author::distinct()->pluck('name');
         $this->assertEquals(4, count($authors));
         $this->assertEquals('Tito', $authors[0]);
         $this->assertEquals('George W. Bush', $authors[1]);
     }
 
+    public function testSingleArgumentWithRemoveDistinct()
+    {
+        $authors = Author::distinct()->distinct(false)->pluck('name');
+        $this->assertEquals(5, count($authors));
+    }
+
     public function testMultipleArguments()
     {
         $authors = Author::pluck('name', 'author_id');
-        $this->assertEquals(4, count($authors));
+        $this->assertEquals(5, count($authors));
         $this->assertEquals('Tito', $authors[0][0]);
         $this->assertEquals(1, $authors[0][1]);
         $this->assertEquals('George W. Bush', $authors[1][0]);
@@ -73,6 +87,6 @@ class ActiveRecordPluckTest extends \DatabaseTestCase
     public function testIdsAll()
     {
         $authors = Author::ids();
-        $this->assertEquals(4, count($authors));
+        $this->assertEquals(5, count($authors));
     }
 }

--- a/test/ActiveRecordPluckTest.php
+++ b/test/ActiveRecordPluckTest.php
@@ -11,21 +11,25 @@ class ActiveRecordPluckTest extends \DatabaseTestCase
     public function testNoArguments()
     {
         $this->expectException(ValidationsArgumentError::class);
-        $author = Author::pluck();
+        Author::pluck();
     }
 
     public function testSingleArgument()
     {
-        $authors = Author::where(['mixedCaseField' => 'Bill'])->pluck('name');
-        $this->assertEquals(2, count($authors));
-        $this->assertEquals('Bill Clinton', $authors[0]);
-        $this->assertEquals('Uncle Bob', $authors[1]);
+        $authors = Author::pluck('name');
+        $this->assertEquals(4, count($authors));
+        $this->assertEquals('Tito', $authors[0]);
+        $this->assertEquals('George W. Bush', $authors[1]);
     }
 
     public function testMultipleArguments()
     {
-        $authors = Author::where(['mixedCaseField' => 'Bill'])->pluck('name', 'author_id');
-        $this->assertMultipleArgumentsResult($authors);
+        $authors = Author::pluck('name', 'author_id');
+        $this->assertEquals(4, count($authors));
+        $this->assertEquals('Tito', $authors[0][0]);
+        $this->assertEquals(1, $authors[0][1]);
+        $this->assertEquals('George W. Bush', $authors[1][0]);
+        $this->assertEquals(2, $authors[1][1]);
     }
 
     public function testCommaDelimitedString()

--- a/test/ActiveRecordTest.php
+++ b/test/ActiveRecordTest.php
@@ -478,6 +478,6 @@ class ActiveRecordTest extends DatabaseTestCase
         $this->assertTrue($row['n'] > 1);
 
         $row = Author::query('SELECT COUNT(*) AS n FROM authors WHERE name=?', ['Tito'])->fetch();
-        $this->assertEquals(['n' => 1], $row);
+        $this->assertEquals(['n' => 2], $row);
     }
 }

--- a/test/ActiveRecordWriteTest.php
+++ b/test/ActiveRecordWriteTest.php
@@ -388,14 +388,13 @@ class ActiveRecordWriteTest extends DatabaseTestCase
     public function testUpdateAllWithSetAsString()
     {
         $num_affected = Author::update_all(['set' => 'parent_author_id = 2']);
-        $this->assertEquals(2, $num_affected);
-        //        $this->assertEquals(4, Author::count_by_parent_author_id(2));
+        $this->assertEquals(3, $num_affected);
     }
 
     public function testUpdateAllWithSetAsHash()
     {
         $num_affected = Author::update_all(['set' => ['parent_author_id' => 2]]);
-        $this->assertEquals(2, $num_affected);
+        $this->assertEquals(3, $num_affected);
     }
 
     /**
@@ -404,19 +403,19 @@ class ActiveRecordWriteTest extends DatabaseTestCase
     public function testUpdateAllWithConditionsAsString()
     {
         $num_affected = Author::update_all(['set' => 'parent_author_id = 2', 'conditions' => 'name = "Tito"']);
-        $this->assertEquals(1, $num_affected);
+        $this->assertEquals(2, $num_affected);
     }
 
     public function testUpdateAllWithConditionsAsHash()
     {
         $num_affected = Author::update_all(['set' => 'parent_author_id = 2', 'conditions' => ['name' => 'Tito']]);
-        $this->assertEquals(1, $num_affected);
+        $this->assertEquals(2, $num_affected);
     }
 
     public function testUpdateAllWithConditionsAsArray()
     {
         $num_affected = Author::update_all(['set' => 'parent_author_id = 2', 'conditions' => ['name = ?', 'Tito']]);
-        $this->assertEquals(1, $num_affected);
+        $this->assertEquals(2, $num_affected);
     }
 
     public function testUpdateAllWithLimitAndOrder()

--- a/test/MysqlAdapterTest.php
+++ b/test/MysqlAdapterTest.php
@@ -33,9 +33,8 @@ class MysqlAdapterTest extends AdapterTestCase
 
     public function testLimitWithNullOffsetDoesNotContainOffset()
     {
-        $ret = [];
-        $sql = 'SELECT * FROM authors ORDER BY name ASC';
-        $this->connection->query_and_fetch($this->connection->limit($sql, 0, 1), function ($row) use (&$ret) { $ret[] = $row; });
+        iterator_to_array($this->connection->query_and_fetch(
+            $this->connection->limit('SELECT * FROM authors ORDER BY name ASC', 0, 1)));
 
         $this->assertTrue(false !== strpos($this->connection->last_query, 'LIMIT 1'));
     }

--- a/test/RelationTest.php
+++ b/test/RelationTest.php
@@ -119,7 +119,7 @@ class RelationTest extends DatabaseTestCase
     public function testAllNoParameters()
     {
         $authors = Author::all()->to_a();
-        $this->assertEquals(4, count($authors));
+        $this->assertEquals(5, count($authors));
     }
 
     public function testCanIterate()

--- a/test/SqliteAdapterTest.php
+++ b/test/SqliteAdapterTest.php
@@ -35,14 +35,13 @@ class SqliteAdapterTest extends AdapterTestCase
 
     public function testLimitWith0OffsetDoesNotContainOffset()
     {
-        $ret = [];
-        $sql = 'SELECT * FROM authors ORDER BY name ASC';
-        $this->connection->query_and_fetch($this->connection->limit($sql, 0, 1), function ($row) use (&$ret) { $ret[] = $row; });
+        $sql = $this->connection->limit('SELECT * FROM authors ORDER BY name ASC', 0, 1);
+        iterator_to_array($this->connection->query_and_fetch($sql));
 
         $this->assertTrue(false !== strpos($this->connection->last_query, 'LIMIT 1'));
     }
 
-    public function testGh183SqliteadapterAutoincrement()
+    public function testSqliteAdapterAutoincrement()
     {
         // defined in lowercase: id integer not null primary key
         $columns = $this->connection->columns('awesome_people');

--- a/test/fixtures/authors.csv
+++ b/test/fixtures/authors.csv
@@ -3,3 +3,4 @@ author_id,parent_author_id,name,mixedCaseField
 2,2,"George W. Bush","George W."
 3,1,"Bill Clinton","Bill"
 4,2,"Uncle Bob","Bill"
+5,1,"Tito","Tito"

--- a/test/helpers/AdapterTestCase.php
+++ b/test/helpers/AdapterTestCase.php
@@ -292,9 +292,8 @@ abstract class AdapterTestCase extends DatabaseTestCase
 
     private function limit(int $offset = 0, int $limit = 0)
     {
-        $ret = [];
         $sql = 'SELECT * FROM authors ORDER BY name ASC';
-        $this->connection->query_and_fetch($this->connection->limit($sql, $offset, $limit), function ($row) use (&$ret) { $ret[] = $row; });
+        $ret = iterator_to_array($this->connection->query_and_fetch($this->connection->limit($sql, $offset, $limit)));
 
         return ActiveRecord\collect($ret, 'author_id');
     }

--- a/test/helpers/AdapterTestCase.php
+++ b/test/helpers/AdapterTestCase.php
@@ -222,6 +222,9 @@ abstract class AdapterTestCase extends DatabaseTestCase
         $this->assertEquals('Tito', $row['name']);
 
         $row = $sth->fetch();
+        $this->assertEquals('Tito', $row['name']);
+
+        $row = $sth->fetch();
         $this->assertEquals('Bill Clinton', $row['name']);
 
         $row = $sth->fetch();


### PR DESCRIPTION
With this change, `pluck` works more like the Rails implementation, in that we talk directly to the database and no models are created.

Also:
* converted `Connection::query_and_fetch` to return a generator so we can clean up all the ugly callback stuff
* added `Relation::distinct()`