### PR TITLE
increase cov in Connection, remove unused

### DIFF
--- a/lib/Model.php
+++ b/lib/Model.php
@@ -1516,7 +1516,7 @@ class Model
 
                 return match ($method) {
                     'build_association' => $association->build_association($this, $args),
-                    'create_association' => $association->create_association($this, $args)
+                    default => $association->create_association($this, $args),
                 };
             }
         }

--- a/lib/Model.php
+++ b/lib/Model.php
@@ -1514,7 +1514,10 @@ class Model
                 // so that we do not double-up on records if we append a newly created
                 $this->initRelationships($association_name);
 
-                return $association->$method($this, $args);
+                return match ($method) {
+                    'build_association' => $association->build_association($this, $args),
+                    'create_association' => $association->create_association($this, $args)
+                };
             }
         }
 

--- a/lib/Relationship/HasMany.php
+++ b/lib/Relationship/HasMany.php
@@ -222,6 +222,7 @@ class HasMany extends AbstractRelationship
     {
         $record = static::build_association($model, $attributes, $guard_attributes);
         $record->save();
+
         return $record;
     }
 

--- a/lib/Relationship/HasMany.php
+++ b/lib/Relationship/HasMany.php
@@ -207,13 +207,11 @@ class HasMany extends AbstractRelationship
     {
         $relationship_attributes = $this->get_foreign_key_for_new_association($model);
 
-        if ($guard_attributes) {
-            // First build the record with just our relationship attributes (unguarded)
-            $record = parent::build_association($model, $relationship_attributes, false);
+        // First build the record with just our relationship attributes (unguarded)
+        $record = parent::build_association($model, $relationship_attributes, false);
 
-            // Then, set our normal attributes (using guarding)
-            $record->set_attributes($attributes);
-        }
+        // Then, set our normal attributes (using guarding)
+        $record->set_attributes($attributes);
 
         return $record;
     }

--- a/lib/cache/Memcache.php
+++ b/lib/cache/Memcache.php
@@ -26,11 +26,8 @@ class Memcache
         $this->memcache = new \Memcache();
         $port = $options['port'] ?? self::DEFAULT_PORT;
         if (!@$this->memcache->connect($options['host'], $port)) {
-            if ($error = error_get_last()) {
-                $message = $error['message'];
-            } else {
-                $message = sprintf('Could not connect to %s:%s', $options['host'], $port);
-            }
+            $error = error_get_last();
+            $message = $error['message'] ?? sprintf('Could not connect to %s:%s', $options['host'], $port);
             throw new CacheException($message);
         }
     }

--- a/test/ConnectionTest.php
+++ b/test/ConnectionTest.php
@@ -60,6 +60,9 @@ class ConnectionTest extends TestCase
     {
         $info = ActiveRecord\Connection::parse_connection_url('mysql://user:password@unix(/tmp/mysql.sock)/database');
         $this->assertEquals('/tmp/mysql.sock', $info['host']);
+
+        $dsn = Connection::data_source_name($info);
+        $this->assertStringContainsString('unix_socket=/tmp/mysql.sock', $dsn);
     }
 
     public function testParseConnectionUrlWithDecodeOption()

--- a/test/RelationshipTest.php
+++ b/test/RelationshipTest.php
@@ -259,10 +259,27 @@ class RelationshipTest extends DatabaseTestCase
 
     public function testHasManyBuildAssociation()
     {
+        $numBooksBeforeBuild = count(Book::all()->to_a());
         $author = Author::first();
         $author->build_book();
+        $numBooksAfterBuild = count(Book::all()->to_a());
         $this->assertEquals($author->id, $author->build_books()->author_id);
         $this->assertEquals($author->id, $author->build_book()->author_id);
+        $this->assertEquals($numBooksBeforeBuild, $numBooksAfterBuild);
+    }
+
+    public function testHasManyCreateAssociation()
+    {
+        $numBooksBeforeBuild = count(Book::all()->to_a());
+        $author = Author::first();
+        $author->build_book();
+        $this->assertEquals($author->id, $author->create_books()->author_id);
+        $this->assertEquals($author->id, $author->create_book()->author_id);
+
+        $numBooksAfterBuild = count(Book::all()->to_a());
+
+        $this->assertEquals($numBooksBeforeBuild, 2);
+        $this->assertEquals($numBooksAfterBuild, 4);
     }
 
     public function testHasAndBelongsToMany()


### PR DESCRIPTION
Some more scattered attempts to increase coverage:

* replace unused `throws` with assert statements
* create `Connection::data_source_name` to exercise unix socket stuff in tests
* test for `create_association`