### PR TITLE
move delete_all to relation

### DIFF
--- a/lib/Model.php
+++ b/lib/Model.php
@@ -1352,11 +1352,6 @@ class Model
                     $exceptions[] = $e->getMessage();
                 }
             } else {
-                // ignore OciAdapter's limit() stuff
-                if ('ar_rnum__' == $name) {
-                    continue;
-                }
-
                 // set arbitrary data
                 $this->assign_attribute($name, $value);
             }

--- a/lib/Model.php
+++ b/lib/Model.php
@@ -1069,59 +1069,12 @@ class Model
     }
 
     /**
-     * Deletes records matching conditions in $options
      *
-     * Does not instantiate models and therefore does not invoke callbacks
-     *
-     * Delete all using a hash:
-     *
-     * ```
-     * YourModel::delete_all(['conditions' => ['name' => 'Tito']]);
-     * ```
-     *
-     * Delete all using an array:
-     *
-     * ```
-     * YourModel::delete_all(['conditions' => ['name = ?', 'Tito']]);
-     * ```
-     *
-     * Delete all using a string:
-     *
-     * ```
-     * YourModel::delete_all(['conditions' => 'name = "Tito"']);
-     * ```
-     *
-     * An options array takes the following parameters:
-     *
-     * @param QueryOptions $options
-     *                              return integer Number of rows affected
+     * @see Relation::delete_all()
      */
-    public static function delete_all(array $options = []): int
+    public static function delete_all(): int
     {
-        $table = static::table();
-        $conn = static::connection();
-        $sql = new SQLBuilder($conn, $table->get_fully_qualified_table_name());
-
-        $conditions = $options['conditions'] ?? $options;
-
-        if (is_array($conditions) && !is_hash($conditions)) {
-            $sql->delete($conditions);
-        } else {
-            $sql->delete($conditions);
-        }
-
-        if (isset($options['limit'])) {
-            $sql->limit($options['limit']);
-        }
-
-        if (isset($options['order'])) {
-            $sql->order($options['order']);
-        }
-
-        $values = $sql->bind_values();
-        $ret = $conn->query($table->last_sql = $sql->to_s(), $values);
-
-        return $ret->rowCount();
+        return static::Relation()->delete_all();
     }
 
     /**

--- a/lib/Model.php
+++ b/lib/Model.php
@@ -1144,7 +1144,13 @@ class Model
             return false;
         }
 
-        static::table()->delete($pk);
+        $options = [
+            'conditions' => [
+                new WhereClause([$this->table()->pk[0] => $pk], [])
+            ]
+        ];
+
+        static::table()->delete($options);
         $this->invoke_callback('after_destroy', false);
         $this->remove_from_cache();
 

--- a/lib/Model.php
+++ b/lib/Model.php
@@ -1069,7 +1069,6 @@ class Model
     }
 
     /**
-     *
      * @see Relation::delete_all()
      */
     public static function delete_all(): int

--- a/lib/Relation.php
+++ b/lib/Relation.php
@@ -868,26 +868,10 @@ class Relation implements \Iterator
     public function delete_all(): int
     {
         $table = static::table();
-        $conn = static::connection();
-        $sql = new SQLBuilder($conn, $table->get_fully_qualified_table_name());
+        $options = array_intersect_key($this->options, array_flip(['limit', 'order']));
+        $count = $table->delete($options);
 
-        $conditions = $this->options;
-
-        $sql->delete($conditions);
-
-        if (isset($options['limit'])) {
-            $sql->limit($options['limit']);
-        }
-
-        if (isset($options['order'])) {
-            $sql->order($options['order']);
-        }
-
-        $values = $sql->bind_values();
-        $ret = $conn->query($table->last_sql = $sql->to_s(), $values);
-
-        return $ret->rowCount();
-
+        return $count;
     }
 
     /**

--- a/lib/Relation.php
+++ b/lib/Relation.php
@@ -868,7 +868,11 @@ class Relation implements \Iterator
     public function delete_all(): int
     {
         $table = static::table();
-        $options = array_intersect_key($this->options, array_flip(['limit', 'order']));
+        $options = array_intersect_key($this->options, array_flip([
+            'conditions',
+            'limit',
+            'order'
+        ]));
         $count = $table->delete($options);
 
         return $count;

--- a/lib/Relation.php
+++ b/lib/Relation.php
@@ -867,15 +867,14 @@ class Relation implements \Iterator
      */
     public function delete_all(): int
     {
-        $table = static::table();
+        $table = $this->table();
         $options = array_intersect_key($this->options, array_flip([
             'conditions',
             'limit',
             'order'
         ]));
-        $count = $table->delete($options);
 
-        return $count;
+        return $table->delete($options);
     }
 
     /**

--- a/lib/Relation.php
+++ b/lib/Relation.php
@@ -867,6 +867,10 @@ class Relation implements \Iterator
      */
     public function delete_all(): int
     {
+        if (isset($this->options['distinct'])) {
+            throw new ActiveRecordException("delete_all doesn't support distinct");
+        }
+
         $table = $this->table();
         $options = array_intersect_key($this->options, array_flip([
             'conditions',

--- a/lib/SQLBuilder.php
+++ b/lib/SQLBuilder.php
@@ -236,7 +236,6 @@ class SQLBuilder
     public function delete(): static
     {
         $this->operation = 'DELETE';
-        isset($arg) && $this->where([WhereClause::from_arg($arg)], []);
 
         return $this;
     }

--- a/lib/SQLBuilder.php
+++ b/lib/SQLBuilder.php
@@ -235,9 +235,6 @@ class SQLBuilder
 
     public function delete(): static
     {
-        $args = func_get_args();
-        $arg = $args[0] ?? null;
-
         $this->operation = 'DELETE';
         isset($arg) && $this->where([WhereClause::from_arg($arg)], []);
 

--- a/lib/Table.php
+++ b/lib/Table.php
@@ -441,15 +441,16 @@ class Table
 
     /**
      * @param RelationOptions $options
-     *
      */
     public function delete(array $options): int
     {
         $sql = $this->options_to_sql($options);
-        $sql->delete([]);
+        $sql->delete();
         $values = $sql->bind_values();
 
-        return $this->conn->query($this->last_sql = $sql->to_s(), $values);
+        $ret = $this->conn->query($this->last_sql = $sql->to_s(), $values);
+
+        return $ret->rowCount();
     }
 
     private function add_relationship(AbstractRelationship $relationship): void

--- a/lib/Table.php
+++ b/lib/Table.php
@@ -440,17 +440,13 @@ class Table
     }
 
     /**
-     * @param array<string,mixed> $data
+     * @param RelationOptions $options
      *
-     * @throws Exception\ActiveRecordException
      */
-    public function delete(array $data): \PDOStatement
+    public function delete(array $options): int
     {
-        $data = $this->process_data($data);
-
-        $sql = new SQLBuilder($this->conn, $this->get_fully_qualified_table_name());
-        $sql->delete($data);
-
+        $sql = $this->options_to_sql($options);
+        $sql->delete([]);
         $values = $sql->bind_values();
 
         return $this->conn->query($this->last_sql = $sql->to_s(), $values);

--- a/test/ActiveRecordWriteTest.php
+++ b/test/ActiveRecordWriteTest.php
@@ -375,7 +375,10 @@ class ActiveRecordWriteTest extends DatabaseTestCase
             $this->markTestSkipped('Only MySQL & Sqlite accept limit/order with UPDATE clause');
         }
 
-        $num_affected = Author::delete_all(['conditions' => ['parent_author_id = ?', 2], 'limit' => 1, 'order' => 'name asc']);
+        $num_affected = Author::limit(1)
+            ->order('name asc')
+            ->where(['parent_author_id = ?', 2])
+            ->delete_all();
         $this->assertEquals(1, $num_affected);
         $this->assertTrue(false !== strpos(Author::table()->last_sql, 'ORDER BY name asc LIMIT 1'));
     }

--- a/test/ActiveRecordWriteTest.php
+++ b/test/ActiveRecordWriteTest.php
@@ -365,7 +365,7 @@ class ActiveRecordWriteTest extends DatabaseTestCase
 
     public function testDeleteAllWithConditionsAsString()
     {
-        $num_affected = Author::delete_all(['conditions' => 'parent_author_id = 2']);
+        $num_affected = Author::where('parent_author_id = ?', 2)->delete_all();
         $this->assertEquals(2, $num_affected);
     }
 

--- a/test/ActiveRecordWriteTest.php
+++ b/test/ActiveRecordWriteTest.php
@@ -363,21 +363,9 @@ class ActiveRecordWriteTest extends DatabaseTestCase
         $this->assertArrayHasKey('some_date', $author->dirty_attributes());
     }
 
-    public function testDeleteAllWithConditionsAsString()
+    public function testDeleteAll()
     {
         $num_affected = Author::where('parent_author_id = ?', 2)->delete_all();
-        $this->assertEquals(2, $num_affected);
-    }
-
-    public function testDeleteAllWithConditionsAsHash()
-    {
-        $num_affected = Author::delete_all(['conditions' => ['parent_author_id' => 2]]);
-        $this->assertEquals(2, $num_affected);
-    }
-
-    public function testDeleteAllWithConditionsAsArray()
-    {
-        $num_affected = Author::delete_all(['conditions' => ['parent_author_id = ?', 2]]);
         $this->assertEquals(2, $num_affected);
     }
 

--- a/test/ActiveRecordWriteTest.php
+++ b/test/ActiveRecordWriteTest.php
@@ -369,6 +369,12 @@ class ActiveRecordWriteTest extends DatabaseTestCase
         $this->assertEquals(2, $num_affected);
     }
 
+    public function testDistinctDeleteAllNotSupported()
+    {
+        $this->expectException(ActiveRecordException::class);
+        Author::distinct()->delete_all();
+    }
+
     public function testDeleteAll()
     {
         $num_affected = Author::delete_all();

--- a/test/ActiveRecordWriteTest.php
+++ b/test/ActiveRecordWriteTest.php
@@ -363,10 +363,16 @@ class ActiveRecordWriteTest extends DatabaseTestCase
         $this->assertArrayHasKey('some_date', $author->dirty_attributes());
     }
 
-    public function testDeleteAll()
+    public function testWhereDeleteAll()
     {
         $num_affected = Author::where('parent_author_id = ?', 2)->delete_all();
         $this->assertEquals(2, $num_affected);
+    }
+
+    public function testDeleteAll()
+    {
+        $num_affected = Author::delete_all();
+        $this->assertEquals(5, $num_affected);
     }
 
     public function testDeleteAllWithLimitAndOrder()

--- a/test/SQLBuilderTest.php
+++ b/test/SQLBuilderTest.php
@@ -193,30 +193,6 @@ class SQLBuilderTest extends DatabaseTestCase
         $this->assertEquals('DELETE FROM authors', $this->sql->to_s());
     }
 
-    public function testDeleteWithWhere()
-    {
-        $this->sql->delete(['id=? or name in(?)', 1, ['Tito', 'Mexican']]);
-        $this->assertEquals('DELETE FROM authors WHERE id=? or name in(?,?)', $this->sql->to_s());
-        $this->assertEquals([1, 'Tito', 'Mexican'], $this->sql->bind_values());
-    }
-
-    public function testDeleteWithHash()
-    {
-        $this->sql->delete(['id' => 1, 'name' => ['Tito', 'Mexican']]);
-        $this->assert_sql_includes('DELETE FROM authors WHERE id = ? AND name IN(?,?)', $this->sql->to_s());
-        $this->assertEquals([1, 'Tito', 'Mexican'], $this->sql->get_where_values());
-    }
-
-    public function testDeleteWithLimitAndOrder()
-    {
-        if (!ConnectionManager::get_connection()->accepts_limit_and_order_for_update_and_delete()) {
-            $this->markTestSkipped('Only MySQL & Sqlite accept limit/order with DELETE operation');
-        }
-
-        $this->sql->delete(['id' => 1])->order('name asc')->limit(1);
-        $this->assert_sql_includes('DELETE FROM authors WHERE id = ? ORDER BY name asc LIMIT 1', $this->sql->to_s());
-    }
-
     public function testReverseOrder()
     {
         $this->assertEquals('id ASC, name DESC', SQLBuilder::reverse_order('id DESC, name ASC'));

--- a/test/helpers/config.php
+++ b/test/helpers/config.php
@@ -39,7 +39,7 @@ ActiveRecord\Config::initialize(function ($cfg) {
         'pgsql'  => getenv('PHPAR_PGSQL') ?: 'pgsql://test:test@127.0.0.1:5432/test',
         'sqlite' => getenv('PHPAR_SQLITE') ?: 'sqlite://test.db']);
 
-    $cfg->set_default_connection('sqlite');
+    $cfg->set_default_connection('mysql');
 
     for ($i=0; $i<count($GLOBALS['argv']); ++$i) {
         if ('--adapter' == $GLOBALS['argv'][$i]) {


### PR DESCRIPTION
Removing the concept of passing conditions to `Model`:

* moved `delete_all` to `Relation`
* changed `Table::delete` to work more similarly to `Table::find`.

Since it now chains off of `Where` like anything else, I was able to remove all the tests that were exercising different args `delete_all`.