### PR TITLE
add interface for cache

### DIFF
--- a/lib/Cache.php
+++ b/lib/Cache.php
@@ -2,6 +2,7 @@
 
 namespace ActiveRecord;
 
+use ActiveRecord\cache\iCache;
 use Closure;
 
 /**
@@ -17,7 +18,7 @@ use Closure;
  */
 class Cache
 {
-    public static ?Memcache $adapter = null;
+    public static ?iCache $adapter = null;
 
     /**
      * @var CacheOptions

--- a/lib/cache/Memcache.php
+++ b/lib/cache/Memcache.php
@@ -2,6 +2,7 @@
 
 namespace ActiveRecord;
 
+use ActiveRecord\cache\iCache;
 use ActiveRecord\Exception\CacheException;
 
 /**
@@ -10,7 +11,7 @@ use ActiveRecord\Exception\CacheException;
  *      port?: int
  *  }
  */
-class Memcache
+class Memcache implements iCache
 {
     public const DEFAULT_PORT = 11211;
 

--- a/lib/cache/iCache.php
+++ b/lib/cache/iCache.php
@@ -2,9 +2,6 @@
 
 namespace ActiveRecord\cache;
 
-use ActiveRecord\Exception\CacheException;
-use ActiveRecord\MemcacheOptions;
-
 interface iCache
 {
     public function flush(): void;
@@ -13,6 +10,8 @@ interface iCache
      * @param list<string>|string $key
      */
     public function read(array|string $key): mixed;
+
     public function write(string $key, mixed $value, int $expire = 0): bool;
+
     public function delete(string $key): bool;
 }

--- a/lib/cache/iCache.php
+++ b/lib/cache/iCache.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace ActiveRecord\cache;
+
+use ActiveRecord\Exception\CacheException;
+use ActiveRecord\MemcacheOptions;
+
+interface iCache
+{
+    public function flush(): void;
+
+    /**
+     * @param list<string>|string $key
+     */
+    public function read(array|string $key): mixed;
+    public function write(string $key, mixed $value, int $expire = 0): bool;
+    public function delete(string $key): bool;
+}


### PR DESCRIPTION
When I was setting up all the typehints for the 2.0 refresh, I annotated  `Cache::$adapter` with `Memcache`.

This was a mistake, because clients will likely use their own cache implementation. In this change, I introduce an `iCache` interface which should be much more friendly. In the future we may want to move to some [kind of standard](https://www.php-fig.org/psr/psr-6/), but no need to get involved in that, now.