### PR TITLE
Integration fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Note that the original website, <http://www.phpactiverecord.org/>, has also fall
  
 http://php-activerecord.github.io/activerecord/
 
-and can be found in in `/docs` if you want to make any changes.
+and can be found in `/docs` if you want to make any changes.
 
 ## Installation
 

--- a/lib/Column.php
+++ b/lib/Column.php
@@ -117,10 +117,16 @@ class Column
             return $value;
         }
 
+        // string representation of a float
+        elseif ((string) (float) $value === $value && (string) (int) $value !== $value) {
+            return (int) $value;
+        }
+
         // If adding 0 to a string causes a float conversion,
         // we have a number over PHP_INT_MAX
-        elseif (is_string($value) && 1 === bccomp($value, (string) PHP_INT_MAX)) {
-            return $value;
+        // @phpstan-ignore-next-line
+        elseif (is_string($value) && is_float($value + 0)) {
+            return (string) $value;
         }
 
         // If a float was passed and is greater than PHP_INT_MAX

--- a/lib/Config.php
+++ b/lib/Config.php
@@ -38,7 +38,7 @@ class Config extends Singleton
      * });
      * ```
      *
-     * This is a singleton class so you can retrieve the {@link Singleton} instance by doing:
+     * This is a singleton class, so you can retrieve the {@link Singleton} instance by doing:
      *
      * ```
      * $config = ActiveRecord\Config::instance();
@@ -59,7 +59,7 @@ class Config extends Singleton
     private bool $logging = false;
 
     /**
-     * Contains a Logger object that must impelement a log() method.
+     * Contains a Logger object that must implement a log() method.
      */
     private LoggerInterface $logger;
 
@@ -202,9 +202,9 @@ class Config extends Singleton
     /**
      * Returns the logger
      */
-    public function get_logger(): LoggerInterface
+    public function get_logger(): LoggerInterface|null
     {
-        return $this->logger;
+        return $this->logger ?? null;
     }
 
     /**

--- a/lib/Connection.php
+++ b/lib/Connection.php
@@ -50,7 +50,7 @@ abstract class Connection
     /**
      * Contains a Logger object that must implement a log() method.
      */
-    private LoggerInterface $logger;
+    private LoggerInterface|null $logger;
     /**
      * The name of the protocol that is used.
      */
@@ -348,9 +348,9 @@ abstract class Connection
     public function query(string $sql, array &$values = [])
     {
         if ($this->logging) {
-            $this->logger->info($sql);
+            $this->logger?->info($sql);
             if ($values) {
-                $this->logger->info(var_export($values, true));
+                $this->logger?->info(var_export($values, true));
             }
         }
 

--- a/lib/Model.php
+++ b/lib/Model.php
@@ -9,7 +9,6 @@ namespace ActiveRecord;
 
 use ActiveRecord\Exception\ActiveRecordException;
 use ActiveRecord\Exception\ReadOnlyException;
-use ActiveRecord\Exception\RecordNotFound;
 use ActiveRecord\Exception\RelationshipException;
 use ActiveRecord\Exception\UndefinedPropertyException;
 use ActiveRecord\Relationship\AbstractRelationship;

--- a/lib/Model.php
+++ b/lib/Model.php
@@ -1444,12 +1444,9 @@ class Model
     /**
      * Enables the use of build|create for associations.
      *
-     * @param string $method Name of method
-     * @param mixed  $args   Method args
-     *
      * @return mixed An instance of a given {@link AbstractRelationship}
      */
-    public function __call($method, $args)
+    public function __call(string $method, mixed $args)
     {
         // check for build|create_association methods
         if (preg_match('/(build|create)_/', $method)) {
@@ -1778,10 +1775,6 @@ class Model
      * 	First Argument								Return Type			Example
      * --------------------------------------------------------------------------------------------
      *	int|string									static				User::find(3);
-     * 	array<string, int|string>					static				User::find(["name"=>"Philip"]);
-     * 	"first"										static|null			User::find("first", ["name"=>"Waldo"]);
-     * 	"last"										static|null			User::find("last", ["name"=>"William"]);
-     *  "all"										static[]			User::find("all", ["name"=>"Stephen"]
      *  ...int|string								static[]			User::find(1, 3, 5, 8);
      *  list<int|string>						    static[]			User::find([1,3,5,8]);
      */

--- a/lib/Model.php
+++ b/lib/Model.php
@@ -1733,52 +1733,11 @@ class Model
     }
 
     /**
-     * Find records in the database.
+     * @see Relation::find()
      *
-     * Finding by the primary key:
-     *
-     * ```
-     * # queries for the model with id=123
-     * YourModel::find(123);
-     *
-     * # queries for model with id in(1,2,3)
-     * YourModel::find(1,2,3);
-     *
-     * # finding by pk accepts an options array
-     * YourModel::find(123, ['order' => 'name desc']);
-     * ```
-     *
-     * Finding by using a conditions array:
-     *
-     * ```
-     * YourModel::find('first', ['conditions' => ['name=?','Tito']],
-     *   'order' => 'name asc'])
-     * YourModel::find('all', ['conditions' => 'amount > 3.14159265']);
-     * YourModel::find('all', ['conditions' => ['id in(?)', [1,2,3]]]);
-     * ```
-     *
-     * Finding by using a hash:
-     *
-     * ```
-     * YourModel::find(['name' => 'Tito', 'id' => 1]);
-     * YourModel::find('first',['name' => 'Tito', 'id' => 1]);
-     * YourModel::find('all',['name' => 'Tito', 'id' => 1]);
-     * ```
-     *
-     * @throws RecordNotFound if no options are passed or finding by pk and no records matched
-     *
-     * @return Model|Model[]|null
-     *
-     * The rules for what gets returned are complex, but predictable:
-     *
-     * /-------------------------------------------------------------------------------------------
-     * 	First Argument								Return Type			Example
-     * --------------------------------------------------------------------------------------------
-     *	int|string									static				User::find(3);
-     *  ...int|string								static[]			User::find(1, 3, 5, 8);
-     *  list<int|string>						    static[]			User::find([1,3,5,8]);
+     * @return static|array<static>
      */
-    public static function find(/* $pk */): Model|array|null
+    public static function find(/* $pk */): Model|array
     {
         return static::Relation()->find(...func_get_args());
     }

--- a/lib/PhpStan/Relation/RelationReflectionHelper.php
+++ b/lib/PhpStan/Relation/RelationReflectionHelper.php
@@ -14,18 +14,6 @@ use PHPStan\Type\UnionType;
 
 trait RelationReflectionHelper
 {
-    protected function isNumericArray(ConstantArrayType $args): bool
-    {
-        $keys = $args->getKeyTypes();
-        foreach ($keys as $key) {
-            if (!($key instanceof IntegerType)) {
-                return false;
-            }
-        }
-
-        return true;
-    }
-
     /**
      * @return string[]
      */
@@ -55,8 +43,7 @@ trait RelationReflectionHelper
                 $nullable = false;
 
                 if (1 == $numArgs) {
-                    if (!($args[0] instanceof ConstantArrayType)
-                        || (!$this->isNumericArray($args[0]))) {
+                    if ((!$args[0]->isArray()->yes())) {
                         $single = true;
                     }
                 } elseif ($numArgs > 1) {

--- a/lib/PhpStan/Relation/RelationReflectionHelper.php
+++ b/lib/PhpStan/Relation/RelationReflectionHelper.php
@@ -5,7 +5,6 @@ namespace ActiveRecord\PhpStan\Relation;
 use PhpParser\Node\Arg;
 use PHPStan\Analyser\Scope;
 use PHPStan\Type\ArrayType;
-use PHPStan\Type\Constant\ConstantArrayType;
 use PHPStan\Type\Constant\ConstantStringType;
 use PHPStan\Type\IntegerType;
 use PHPStan\Type\NullType;
@@ -43,7 +42,7 @@ trait RelationReflectionHelper
                 $nullable = false;
 
                 if (1 == $numArgs) {
-                    if ((!$args[0]->isArray()->yes())) {
+                    if (!$args[0]->isArray()->yes()) {
                         $single = true;
                     }
                 } elseif ($numArgs > 1) {

--- a/lib/Relation.php
+++ b/lib/Relation.php
@@ -177,7 +177,8 @@ class Relation implements \Iterator
                 return $this->className::create(SQLBuilder::create_hash_from_underscored_string(
                     $attributes,
                     $args,
-                    $this->alias_attribute));
+                    $this->alias_attribute
+                ));
             }
 
             return null;
@@ -306,7 +307,7 @@ class Relation implements \Iterator
      *
      * @param string|array<string> $joins
      *
-     * @returns Relation<TModel>
+     * @return Relation<TModel>
      */
     public function joins(string|array $joins): Relation
     {

--- a/test/ActiveRecordPHPStanTest.php
+++ b/test/ActiveRecordPHPStanTest.php
@@ -14,32 +14,32 @@ class ActiveRecordPHPStanTest extends \DatabaseTestCase
     public function testPhpstan()
     {
         $this->expectNotToPerformAssertions();
-        //        $version = 'Version unknown';
-        //        try {
-        //            $version = \Jean85\PrettyVersions::getVersion(
-        //                'phpstan/phpstan'
-        //            )->getPrettyVersion();
-        //        } catch (\OutOfBoundsException $e) {
-        //        }
-        //
-        //        $application = new Application(
-        //            'PHPStan - PHP Static Analysis Tool',
-        //            $version
-        //        );
-        //        $application->setAutoExit(false);
-        //        $application->add(new AnalyseCommand([]));
-        //        $application->run(
-        //            new \_PHPStan_a4fa95a42\Symfony\Component\Console\Input\ArgvInput(
-        //                [
-        //                    'vendor/phpstan/phpstan/bin/phpstan',
-        //                    'analyse',
-        //                    '--xdebug',
-        //                    '--debug',
-        //                    '-c',
-        //                    './phpstan.neon.dist',
-        //                    'test/phpstan',
-        //                ]
-        //            )
-        //        );
+                $version = 'Version unknown';
+                try {
+                    $version = \Jean85\PrettyVersions::getVersion(
+                        'phpstan/phpstan'
+                    )->getPrettyVersion();
+                } catch (\OutOfBoundsException $e) {
+                }
+
+                $application = new Application(
+                    'PHPStan - PHP Static Analysis Tool',
+                    $version
+                );
+                $application->setAutoExit(false);
+                $application->add(new AnalyseCommand([]));
+                $application->run(
+                    new \_PHPStan_a4fa95a42\Symfony\Component\Console\Input\ArgvInput(
+                        [
+                            'vendor/phpstan/phpstan/bin/phpstan',
+                            'analyse',
+                            '--xdebug',
+                            '--debug',
+                            '-c',
+                            './phpstan.neon.dist',
+                            'test/phpstan/RelationFindDynamicReturn.php',
+                        ]
+                    )
+                );
     }
 }

--- a/test/ActiveRecordPHPStanTest.php
+++ b/test/ActiveRecordPHPStanTest.php
@@ -14,32 +14,32 @@ class ActiveRecordPHPStanTest extends \DatabaseTestCase
     public function testPhpstan()
     {
         $this->expectNotToPerformAssertions();
-                $version = 'Version unknown';
-                try {
-                    $version = \Jean85\PrettyVersions::getVersion(
-                        'phpstan/phpstan'
-                    )->getPrettyVersion();
-                } catch (\OutOfBoundsException $e) {
-                }
-
-                $application = new Application(
-                    'PHPStan - PHP Static Analysis Tool',
-                    $version
-                );
-                $application->setAutoExit(false);
-                $application->add(new AnalyseCommand([]));
-                $application->run(
-                    new \_PHPStan_a4fa95a42\Symfony\Component\Console\Input\ArgvInput(
-                        [
-                            'vendor/phpstan/phpstan/bin/phpstan',
-                            'analyse',
-                            '--xdebug',
-                            '--debug',
-                            '-c',
-                            './phpstan.neon.dist',
-                            'test/phpstan/RelationFindDynamicReturn.php',
-                        ]
-                    )
-                );
+        //        $version = 'Version unknown';
+        //        try {
+        //            $version = \Jean85\PrettyVersions::getVersion(
+        //                'phpstan/phpstan'
+        //            )->getPrettyVersion();
+        //        } catch (\OutOfBoundsException $e) {
+        //        }
+        //
+        //        $application = new Application(
+        //            'PHPStan - PHP Static Analysis Tool',
+        //            $version
+        //        );
+        //        $application->setAutoExit(false);
+        //        $application->add(new AnalyseCommand([]));
+        //        $application->run(
+        //            new \_PHPStan_a4fa95a42\Symfony\Component\Console\Input\ArgvInput(
+        //                [
+        //                    'vendor/phpstan/phpstan/bin/phpstan',
+        //                    'analyse',
+        //                    '--xdebug',
+        //                    '--debug',
+        //                    '-c',
+        //                    './phpstan.neon.dist',
+        //                    'test/phpstan',
+        //                ]
+        //            )
+        //        );
     }
 }

--- a/test/helpers/config.php
+++ b/test/helpers/config.php
@@ -23,10 +23,10 @@ require_once 'AdapterTestCase.php';
 
 require_once __DIR__ . '/../../ActiveRecord.php';
 
-// whether or not to run the slow non-crucial tests
+// whether to run the slow non-crucial tests
 $GLOBALS['slow_tests'] = false;
 
-// whether or not to show warnings when Log or Memcache is missing
+// whether to show warnings when Log or Memcache is missing
 $GLOBALS['show_warnings'] = true;
 
 if ('false' !== getenv('LOG')) {

--- a/test/phpstan/RelationFindDynamicReturn.php
+++ b/test/phpstan/RelationFindDynamicReturn.php
@@ -28,14 +28,14 @@ class RelationFindDynamicReturn
         /**
          * @var non-empty-array<int>
          */
-//        $ids = [];
-//
-//        $this->book = Book::All()->find(1);
-//        $this->books = Book::All()->find([1, 2]);
-//        $this->books = Book::All()->find($ids);
-//
-//        $books = Book::find($ids);
-//        $this->books = $books;
+        $ids = [];
+
+        $this->book = Book::All()->find(1);
+        $this->books = Book::All()->find([1, 2]);
+        $this->books = Book::All()->find($ids);
+
+        $books = Book::find($ids);
+        $this->books = $books;
 
         /**
          * @var mixed $mixed;

--- a/test/phpstan/RelationFindDynamicReturn.php
+++ b/test/phpstan/RelationFindDynamicReturn.php
@@ -9,7 +9,6 @@
  */
 
 use test\models\Book;
-use function PHPStan\dumpType;
 
 class RelationFindDynamicReturn
 {
@@ -37,9 +36,6 @@ class RelationFindDynamicReturn
         $books = Book::find($ids);
         $this->books = $books;
 
-        /**
-         * @var mixed $mixed;
-         */
         $mixed = 1;
         $books = Book::find($mixed);
         $this->book = $books;

--- a/test/phpstan/RelationFindDynamicReturn.php
+++ b/test/phpstan/RelationFindDynamicReturn.php
@@ -9,6 +9,7 @@
  */
 
 use test\models\Book;
+use function PHPStan\dumpType;
 
 class RelationFindDynamicReturn
 {
@@ -24,7 +25,23 @@ class RelationFindDynamicReturn
 
     public function __construct()
     {
-        $this->book = Book::All()->find(1);
-        $this->books = Book::All()->find([1, 2]);
+        /**
+         * @var non-empty-array<int>
+         */
+//        $ids = [];
+//
+//        $this->book = Book::All()->find(1);
+//        $this->books = Book::All()->find([1, 2]);
+//        $this->books = Book::All()->find($ids);
+//
+//        $books = Book::find($ids);
+//        $this->books = $books;
+
+        /**
+         * @var mixed $mixed;
+         */
+        $mixed = 1;
+        $books = Book::find($mixed);
+        $this->book = $books;
     }
 }


### PR DESCRIPTION
I spent the evening trying to integrate the 2.0 stuff into my private project, and wound up having to fix several little issues that didn't come up before:

* fixed several typos
* handle the case that client doesn't supply a logger
* fixed docs for `Model::find`
* greatly simplified the dynamic return extension stuff (before, it only detected array type if the one-and-only argument was a `ConstArrayType`, now it only decides an array if trinary `YES` and anything else (`NO` or `MAYBE` ) is interpreted to be a single.
* removed the dependency on `bccomp`, and added PHPStan ignore statement for the weird out-of-range int checking trick.

I still have at least one issue around `bccomp` to sort out, but otherwise everything was pretty simple and took only a few hours to port over (with much of that time consumed by the fixes I had to do in this library).