### PR TITLE
Modernize Model::update_all

### DIFF
--- a/lib/Model.php
+++ b/lib/Model.php
@@ -1013,7 +1013,7 @@ class Model
      *
      * @return bool True if the model was saved to the database otherwise false
      */
-    private function update($validate = true)
+    private function update(bool $validate = true)
     {
         $this->verify_not_readonly('update');
 
@@ -1083,6 +1083,8 @@ class Model
     }
 
     /**
+     * @param string|Attributes $attributes
+     *
      * @see Relation::update_all()
      */
     public static function update_all(string|array $attributes): int

--- a/lib/Model.php
+++ b/lib/Model.php
@@ -1084,7 +1084,6 @@ class Model
 
     /**
      * @see Relation::update_all()
-     *
      */
     public static function update_all(string|array $attributes): int
     {

--- a/lib/Relation.php
+++ b/lib/Relation.php
@@ -848,25 +848,37 @@ class Relation implements \Iterator
     }
 
     /**
-     * Updates records using set in $options
+     * Updates all records in the current relation with provided attributes.
+     * This method constructs a single SQL UPDATE statement and sends it
+     * straight to the database. It does not instantiate the involved models
+     * and it does not trigger Active Record callbacks or validations.
+     * However, values passed to #update_all will still go through Active
+     * Record's normal type casting and serialization. Returns the number of
+     * rows affected.
      *
-     * Does not instantiate models and therefore does not invoke callbacks
+     * Note: As Active Record callbacks are not triggered, this method will
+     * not automatically update updated_at+/+updated_on columns.
      *
-     * Update all using a hash:
+     * // Update all customers with the given attributes
+     * Customer::update_all( ['wants_email'] => true)
      *
-     * ```
-     * YourModel::update_all(['set' => ['name' => "Bob"]]);
-     * ```
+     * // Update all books with 'Rails' in their title
+     * Book::where('title LIKE ?', '%Rails%')
+     *   ->update_all(['author', 'David'])
      *
-     * Update all using a string:
+     * // Update all books that match conditions, but limit it to 5 ordered by date
+     * Book::where('title LIKE ?', '%Rails%')
+     *   ->order('created_at')
+     *   ->limit(5)
+     *   ->update_all(['author'=> 'David'])
      *
-     * ```
-     * YourModel::update_all(['set' => 'name = "Bob"']);
-     * ```
+     * // Update all invoices and set the number column to its id value.
+     * Invoice::update_all('number = id')
      *
-     * An options array takes the following parameters:
+     * @param string|Attributes $attributes A string or hash representing the SET part of
+     * an SQL statement.
      *
-     * @return int Number of rows affected
+     * @return int number of affected records
      */
     public function update_all(array|string $attributes): int
     {

--- a/lib/Relation.php
+++ b/lib/Relation.php
@@ -15,6 +15,7 @@ use ActiveRecord\Exception\ValidationsArgumentError;
  * @template TModel of Model
  *
  * @phpstan-import-type RelationOptions from Types
+ * @phpstan-import-type Attributes from Types
  */
 class Relation implements \Iterator
 {
@@ -844,6 +845,34 @@ class Relation implements \Iterator
     public function to_a(): array
     {
         return $this->_to_a($this->options);
+    }
+
+    /**
+     * Updates records using set in $options
+     *
+     * Does not instantiate models and therefore does not invoke callbacks
+     *
+     * Update all using a hash:
+     *
+     * ```
+     * YourModel::update_all(['set' => ['name' => "Bob"]]);
+     * ```
+     *
+     * Update all using a string:
+     *
+     * ```
+     * YourModel::update_all(['set' => 'name = "Bob"']);
+     * ```
+     *
+     * An options array takes the following parameters:
+     *
+     * @param Attributes $options
+     *
+     * @return int Number of rows affected
+     */
+    public function update_all(array|string $attributes): int
+    {
+        return $this->table()->update($attributes, $this->options);
     }
 
     /**

--- a/lib/Relation.php
+++ b/lib/Relation.php
@@ -875,8 +875,8 @@ class Relation implements \Iterator
      * // Update all invoices and set the number column to its id value.
      * Invoice::update_all('number = id')
      *
-     * @param string|Attributes $attributes A string or hash representing the SET part of
-     * an SQL statement.
+     * @param string|Attributes $attributes a string or hash representing the SET part of
+     *                                      an SQL statement
      *
      * @return int number of affected records
      */

--- a/lib/Relation.php
+++ b/lib/Relation.php
@@ -866,8 +866,6 @@ class Relation implements \Iterator
      *
      * An options array takes the following parameters:
      *
-     * @param Attributes $options
-     *
      * @return int Number of rows affected
      */
     public function update_all(array|string $attributes): int

--- a/lib/SQLBuilder.php
+++ b/lib/SQLBuilder.php
@@ -216,8 +216,6 @@ class SQLBuilder
     }
 
     /**
-     * @param Attributes|string $attributes
-     *
      * @throws ActiveRecordException
      */
     public function update(array|string $data): static

--- a/lib/SQLBuilder.php
+++ b/lib/SQLBuilder.php
@@ -216,18 +216,18 @@ class SQLBuilder
     }
 
     /**
-     * @param Attributes|string $mixed
+     * @param Attributes|string $attributes
      *
      * @throws ActiveRecordException
      */
-    public function update(array|string $mixed): static
+    public function update(array|string $data): static
     {
         $this->operation = 'UPDATE';
 
-        if (is_hash($mixed)) {
-            $this->data = $mixed;
-        } elseif (is_string($mixed)) {
-            $this->update = $mixed;
+        if (is_hash($data)) {
+            $this->data = $data;
+        } elseif (is_string($data)) {
+            $this->update = $data;
         }
 
         return $this;

--- a/lib/SQLBuilder.php
+++ b/lib/SQLBuilder.php
@@ -216,6 +216,8 @@ class SQLBuilder
     }
 
     /**
+     * @param string|Attributes $data
+     *
      * @throws ActiveRecordException
      */
     public function update(array|string $data): static

--- a/lib/Table.php
+++ b/lib/Table.php
@@ -422,21 +422,19 @@ class Table
     }
 
     /**
-     * @param Attributes $data
-     * @param Attributes $where
+     * @param string|Attributes $attributes
+     * @param Attributes $options
      *
      * @throws Exception\ActiveRecordException
      */
-    public function update(array &$data, array $where): \PDOStatement
+    public function update(string|array $attributes, array $options): int
     {
-        $data = $this->process_data($data);
-
-        $sql = new SQLBuilder($this->conn, $this->get_fully_qualified_table_name());
-        $sql->update($data)->where([new WhereClause($where, [])], []);
-
+        $sql = $this->options_to_sql($options);
+        $sql->update($attributes);
         $values = $sql->bind_values();
+        $ret = $this->conn->query($this->last_sql = $sql->to_s(), $values);
 
-        return $this->conn->query($this->last_sql = $sql->to_s(), $values);
+        return $ret->rowCount();
     }
 
     /**

--- a/lib/Table.php
+++ b/lib/Table.php
@@ -423,13 +423,16 @@ class Table
 
     /**
      * @param string|Attributes $attributes
-     * @param Attributes $options
+     * @param Attributes        $options
      *
      * @throws Exception\ActiveRecordException
      */
     public function update(string|array $attributes, array $options): int
     {
         $sql = $this->options_to_sql($options);
+        if (is_hash($attributes)) {
+            $attributes = $this->process_data($attributes);
+        }
         $sql->update($attributes);
         $values = $sql->bind_values();
         $ret = $this->conn->query($this->last_sql = $sql->to_s(), $values);

--- a/test/ActiveRecordWriteTest.php
+++ b/test/ActiveRecordWriteTest.php
@@ -395,18 +395,18 @@ class ActiveRecordWriteTest extends DatabaseTestCase
         Author::distinct()->where('parent_author_id = 2')->delete_all();
     }
 
-    public function testUpdateAllWithSetAsString()
+    public function testUpdateAllWithString()
     {
-        Author::update_all(['set' => 'parent_author_id = 2']);
+        Author::update_all('parent_author_id = 2');
         $ids = Author::pluck('parent_author_id');
         foreach ($ids as $id) {
             $this->assertEquals(2, $id);
         }
     }
 
-    public function testUpdateAllWithSetAsHash()
+    public function testUpdateAllWithHash()
     {
-        Author::update_all(['set' => ['parent_author_id' => 2]]);
+        Author::update_all(['parent_author_id' => 2]);
         $ids = Author::pluck('parent_author_id');
         foreach ($ids as $id) {
             $this->assertEquals(2, $id);
@@ -427,18 +427,15 @@ class ActiveRecordWriteTest extends DatabaseTestCase
 
     public function testUpdateAllWithConditionsAsHash()
     {
-        $num_affected = Author::update_all([
-            'set' => 'parent_author_id = 2',
-            'conditions' => [
-                'name' => 'Tito'
-            ]
-        ]);
+        $num_affected = Author::where([
+            'name' => 'Tito'
+        ])->update_all('parent_author_id = 2');
         $this->assertEquals(2, $num_affected);
     }
 
     public function testUpdateAllWithConditionsAsArray()
     {
-        $num_affected = Author::update_all(['set' => 'parent_author_id = 2', 'conditions' => ['name = ?', 'Tito']]);
+        $num_affected = Author::where(['name = ?', 'Tito'])->update_all('parent_author_id = 2');
         $this->assertEquals(2, $num_affected);
     }
 
@@ -448,7 +445,10 @@ class ActiveRecordWriteTest extends DatabaseTestCase
             $this->markTestSkipped('Only MySQL & Sqlite accept limit/order with UPDATE clause');
         }
 
-        $num_affected = Author::update_all(['set' => 'parent_author_id = 2', 'limit' => 1, 'order' => 'name asc']);
+        $num_affected = Author::limit(1)
+            ->order('name asc')
+            ->update_all('parent_author_id = 2');
+
         $this->assertEquals(1, $num_affected);
         $this->assertTrue(false !== strpos(Author::table()->last_sql, 'ORDER BY name asc LIMIT 1'));
     }

--- a/test/ActiveRecordWriteTest.php
+++ b/test/ActiveRecordWriteTest.php
@@ -418,10 +418,7 @@ class ActiveRecordWriteTest extends DatabaseTestCase
      */
     public function testUpdateAllWithConditionsAsString()
     {
-        $num_affected = Author::update_all([
-            'set' => 'parent_author_id = 2',
-            'conditions' => ['name = ?', 'Tito']
-        ]);
+        $num_affected = Author::where(['name = ?', 'Tito'])->update_all('parent_author_id = 2');
         $this->assertEquals(2, $num_affected);
     }
 


### PR DESCRIPTION
Fix for #102 

Modernize `Model::update_all`, meaning that it no longer takes a big hairy argument with `conditions` and `set` and whatnot--now you can use it in conjunction with `where`, the same as everything else.
