### PR TITLE
remove unused logic

### DIFF
--- a/lib/WhereClause.php
+++ b/lib/WhereClause.php
@@ -233,15 +233,6 @@ class WhereClause
 
         if (is_array($value)) {
             $value_count = count($value);
-
-            if (0 === $value_count) {
-                if ($substitute) {
-                    return 'NULL';
-                }
-
-                return self::ParameterMarker;
-            }
-
             if ($substitute) {
                 $ret = '';
 


### PR DESCRIPTION
I think the intent here is correct; if you pass in an empty array, then it should equate to checking for `null`, but as far as I can tell this logic has always been unreachable, because we currently throw an exception if the number of vars doesn't match the number of `?` tokens. Can revisit someday.