### PR TITLE
throw RecordNotFound on empty find

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -33,6 +33,17 @@ $books = Book::find([1,2,3], ['conditions'=>['title = ?', 'Walden']]);
 $books = Book::where('title = ?', 'Walden')->to_a();
 ```
 
+Also, in 2.x we have fixed a bug around calling `find` with an empty array. It will now throw a `RecordNotFound` exception. If you were relying on the old behavior, you should switch to `where`:
+```php
+// 1.x
+$ids = [];
+$books = Book::find($ids);
+
+// 2.0
+$books = Book::where(['book_id' => $ids])->to_a();
+```
+
+
 The `all` argument has been removed in favor of `Relation::all`:
 ```php
 // 1.x

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "keywords": ["activerecord", "orm"],
     "homepage": "http://www.phpactiverecord.org/",
     "license": "MIT",
-    "version": "2.0.0-rc.6",
+    "version": "2.0.0-rc.7",
     "require": {
         "php": ">=8.1.0",
         "ext-bcmath": "*"

--- a/lib/Relation.php
+++ b/lib/Relation.php
@@ -719,8 +719,8 @@ class Relation implements \Iterator
         $options['conditions'] ??= [];
         $options['conditions'][] = $this->pk_conditions($args);
 
-        if (is_array($args) && count($args) === 0) {
-            throw new RecordNotFound("Couldn't find " . $this->className . " without an ID");
+        if (is_array($args) && 0 === count($args)) {
+            throw new RecordNotFound("Couldn't find " . $this->className . ' without an ID');
         }
 
         $list = $this->_to_a($options);

--- a/lib/Relation.php
+++ b/lib/Relation.php
@@ -720,7 +720,7 @@ class Relation implements \Iterator
         $options['conditions'][] = $this->pk_conditions($args);
 
         if (is_array($args) && 0 === count($args)) {
-            throw new RecordNotFound("Couldn't find " . $this->className . ' without an ID');
+//            throw new RecordNotFound("Couldn't find " . $this->className . ' without an ID');
         }
 
         $list = $this->_to_a($options);

--- a/lib/Relation.php
+++ b/lib/Relation.php
@@ -719,6 +719,10 @@ class Relation implements \Iterator
         $options['conditions'] ??= [];
         $options['conditions'][] = $this->pk_conditions($args);
 
+        if (is_array($args) && count($args) === 0) {
+            throw new RecordNotFound("Couldn't find " . $this->className . " without an ID");
+        }
+
         $list = $this->_to_a($options);
         if (is_array($args) && count($list) != count($args)) {
             throw new RecordNotFound('found ' . count($list) . ', but was looking for ' . count($args));

--- a/lib/Relation.php
+++ b/lib/Relation.php
@@ -720,7 +720,7 @@ class Relation implements \Iterator
         $options['conditions'][] = $this->pk_conditions($args);
 
         if (is_array($args) && 0 === count($args)) {
-//            throw new RecordNotFound("Couldn't find " . $this->className . ' without an ID');
+            throw new RecordNotFound("Couldn't find " . $this->className . ' without an ID');
         }
 
         $list = $this->_to_a($options);

--- a/lib/Table.php
+++ b/lib/Table.php
@@ -492,7 +492,8 @@ class Table
 
     private function set_primary_key(): void
     {
-        if (($pk = $this->class->getStaticPropertyValue('pk', null)) || ($pk = $this->class->getStaticPropertyValue('primary_key', null))) {
+        $pk = $this->class->getStaticPropertyValue('pk', null) ?? $this->class->getStaticPropertyValue('primary_key', null);
+        if ($pk) {
             $this->pk = is_array($pk) ? $pk : [$pk];
         } else {
             $this->pk = [];
@@ -507,7 +508,8 @@ class Table
 
     private function set_table_name(): void
     {
-        if (($table = $this->class->getStaticPropertyValue('table', null)) || ($table = $this->class->getStaticPropertyValue('table_name', null))) {
+        $table = $this->class->getStaticPropertyValue('table', null) ?? $this->class->getStaticPropertyValue('table_name', null);
+        if ($table) {
             $this->table = $table;
         } else {
             // infer table name from the class name

--- a/lib/Table.php
+++ b/lib/Table.php
@@ -492,7 +492,7 @@ class Table
 
     private function set_primary_key(): void
     {
-        $pk = $this->class->getStaticPropertyValue('pk', null) ?? $this->class->getStaticPropertyValue('primary_key', null);
+        $pk = $this->class->getStaticPropertyValue('pk', null) ?? $this->class->getStaticPropertyValue('primary_key', null) ?? null;
         if (isset($pk)) {
             $this->pk = is_array($pk) ? $pk : [$pk];
         } else {
@@ -508,7 +508,7 @@ class Table
 
     private function set_table_name(): void
     {
-        $table = $this->class->getStaticPropertyValue('table', null) ?? $this->class->getStaticPropertyValue('table_name', null);
+        $table = $this->class->getStaticPropertyValue('table', null) ?? $this->class->getStaticPropertyValue('table_name', null) ?? null;
         if (isset($table)) {
             $this->table = $table;
         } else {
@@ -520,7 +520,7 @@ class Table
             $this->table = $parts[count($parts) - 1];
         }
 
-        $db = $this->class->getStaticPropertyValue('db', null) ?? $this->class->getStaticPropertyValue('db_name', null);
+        $db = $this->class->getStaticPropertyValue('db', null) ?? $this->class->getStaticPropertyValue('db_name', null) ?? null;
         if (isset($db)) {
             $this->db_name = $db;
         }

--- a/lib/Table.php
+++ b/lib/Table.php
@@ -493,7 +493,7 @@ class Table
     private function set_primary_key(): void
     {
         $pk = $this->class->getStaticPropertyValue('pk', null) ?? $this->class->getStaticPropertyValue('primary_key', null);
-        if ($pk) {
+        if (isset($pk)) {
             $this->pk = is_array($pk) ? $pk : [$pk];
         } else {
             $this->pk = [];
@@ -509,7 +509,7 @@ class Table
     private function set_table_name(): void
     {
         $table = $this->class->getStaticPropertyValue('table', null) ?? $this->class->getStaticPropertyValue('table_name', null);
-        if ($table) {
+        if (isset($table)) {
             $this->table = $table;
         } else {
             // infer table name from the class name
@@ -521,7 +521,7 @@ class Table
         }
 
         $db = $this->class->getStaticPropertyValue('db', null) ?? $this->class->getStaticPropertyValue('db_name', null);
-        if ($db) {
+        if (isset($db)) {
             $this->db_name = $db;
         }
     }

--- a/test/ActiveRecordFindTest.php
+++ b/test/ActiveRecordFindTest.php
@@ -17,6 +17,13 @@ class ActiveRecordFindTest extends DatabaseTestCase
         Author::find();
     }
 
+    public function testFindWithEmptyArray()
+    {
+        $this->expectException(RecordNotFound::class);
+        $this->expectExceptionMessage("Couldn't find test\models\Author without an ID");
+        Author::find([]);
+    }
+
     public function testFindReturnsSingleModel()
     {
         $author = Author::select('author_id')->find(3);


### PR DESCRIPTION
If I understand correctly, Rails throws a `RecordNotFound` exception when you pass an empty array to `find`, and we don't seem to be doing that. I still have a little more research to do, but opening a PR in the meantime.

Also, there are a few points in the code where we retrieve static members from classes via reflection that may or may not exist, and this was throwing warnings.