### PR TITLE
simplify count

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "keywords": ["activerecord", "orm"],
     "homepage": "http://www.phpactiverecord.org/",
     "license": "MIT",
-    "version": "2.0.0-rc.7",
+    "version": "2.0.0-rc.8",
     "require": {
         "php": ">=8.1.0",
         "ext-bcmath": "*"

--- a/lib/WhereClause.php
+++ b/lib/WhereClause.php
@@ -91,6 +91,10 @@ class WhereClause
         $num_values = count($values);
         $quotes = 0;
 
+        if (1 == $num_values && is_array($values[0]) && 0 == count($values[0])) {
+            return '1=0';
+        }
+
         for ($i = 0, $j = 0; $i < strlen($expression); ++$i) {
             $ch = $expression[$i];
 

--- a/lib/WhereClause.php
+++ b/lib/WhereClause.php
@@ -88,11 +88,7 @@ class WhereClause
         }
 
         $ret = '';
-        if (1 == count($values) && is_array($values[0])) {
-            $num_values = count($values[0]);
-        } else {
-            $num_values = count($values);
-        }
+        $num_values = count($values);
         $quotes = 0;
 
         for ($i = 0, $j = 0; $i < strlen($expression); ++$i) {

--- a/test/ActiveRecordFindTest.php
+++ b/test/ActiveRecordFindTest.php
@@ -1,6 +1,5 @@
 <?php
 
-use ActiveRecord\Exception\DatabaseException;
 use ActiveRecord\Exception\RecordNotFound;
 use ActiveRecord\Exception\ValidationsArgumentError;
 use ActiveRecord\Model;
@@ -15,6 +14,12 @@ class ActiveRecordFindTest extends DatabaseTestCase
     {
         $this->expectException(ValidationsArgumentError::class);
         Author::find();
+    }
+
+    public function testWhereWithEmptyArray()
+    {
+        $authors = Author::where(['author_id' => []])->to_a();
+        $this->assertEquals(0, count($authors));
     }
 
     public function testFindWithEmptyArray()
@@ -164,13 +169,6 @@ class ActiveRecordFindTest extends DatabaseTestCase
     {
         $authors = Author::where('author_id IN(1,2,3)')->to_a();
         $this->assertEquals(1, $authors[0]->author_id);
-    }
-
-    public function testFindAllWithEmptyArrayBindValueThrowsException()
-    {
-        $this->expectException(DatabaseException::class);
-        $this->expectExceptionMessage('No bound parameter for index 0');
-        Author::where(['author_id IN(?)', []])->to_a();
     }
 
     public function testFindHashUsingAlias()

--- a/test/WhereClauseTest.php
+++ b/test/WhereClauseTest.php
@@ -3,7 +3,6 @@
 use ActiveRecord\ConnectionManager;
 use ActiveRecord\Exception\DatabaseException;
 use ActiveRecord\WhereClause;
-use test\models\Author;
 
 class WhereClauseTest extends DatabaseTestCase
 {
@@ -133,12 +132,6 @@ class WhereClauseTest extends DatabaseTestCase
         $a = new WhereClause('name=?', ["Tito's Guild"]);
         $escaped = ConnectionManager::get_connection()->escape("Tito's Guild");
         $this->assertEquals("name=$escaped", $a->to_s(ConnectionManager::get_connection(), substitute: true));
-    }
-
-    public function testBindInvalidParameterNumberArrayWithIn()
-    {
-        $this->expectException(DatabaseException::class);
-        Author::where(['author_id IN(?)', []])->to_a();
     }
 
     public function testSubstituteUsingAlternateValues(): void


### PR DESCRIPTION
Another subtle fix. Apparently, rails does not throw an exception if you do a `where` with an empty array. Both of these should return an empty array, not throw:

```php
Author::where(['author_id IN(?)', []])->to_a();
```

```php
Author::where(['author_id' => []])->to_a();
```

Rails optimize this under the hood by just doing an always-false clause, ie:

```
WHERE 1=0
```