### PR TITLE
fix type

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -142,7 +142,7 @@ Book::table()->update($attributes, $where);
 Book::where($where)->update_all($attributes);
 ```
 
-If you do need access to the table for some reason, you can still get to it:
+If you do need access to the table instance for some reason, you can still get to it:
 ```php
   $table = Table::load(Book::class);
 ```
@@ -262,11 +262,29 @@ You generally shouldn't be working directly with a `Table` instance, but if you 
 ```php
 // 1.x 
 $table = Book::table();
-$table->update()
+$table->update([ 'title' => 'Walden` ], ['author_id` => 1]);
 
 // 2.0
 $table = Table::load(Book::class);
-$table
+$options = [
+    'conditions' => [new WhereClause(['author_id` => 1])]
+];
+$table->update([ 'title' => 'Walden' ], $options); // where $options is a RelationOptions.
+```
+
+## `Table::delete`
+You generally shouldn't be working directly with a `Table` instance, but if you are you should be aware that the `delete` method has changed shape:
+```php
+// 1.x 
+$table = Book::table();
+$table->delete(['author_id' => 1]);
+
+// 2.0
+$table = Table::load(Book::class);
+$options = [
+    'conditions' => [new WhereClause(['author_id` => 1])]
+];
+$table->delete($options); // where $options is a RelationOptions.
 ```
 
 ## `Config::set_model_directory`

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -9,6 +9,7 @@
 - [Model::delete_all()](#modeldelete_all)
 - [Model::update_all()](#modelupdate_all)
 - [Model::find_all_by_...()](#modelfind_all_by_attribute)
+- [Model::table()](#modeltable)
 
 #### static properties 
 
@@ -18,6 +19,8 @@
 - [Model::$validates_inclusion_of](#modelvalidates_inclusion_of)
 
 #### other changes
+- [Table::delete](#tabledelete)
+- [Table::update](#tableupdate)
 - [Config::set_model_directory](#configset_model_directory)
 - [exceptions location](#exceptions-location)
 
@@ -129,6 +132,22 @@ $books = Book::find_all_by_title('Ubik');
 $books = Book::where('title = ?', 'Ubik')->to_a();
 ```
 
+## `Model::table`
+The static `table` accessor on `Model` is now protected. If you were making calls directly on `Table`, you will need to refactor your code.
+```php
+// 1.x
+Book::table()->update($attributes, $where);
+
+// 2.0
+Book::where($where)->update_all($attributes);
+```
+
+If you do need access to the table for some reason, you can still get to it:
+```php
+  $table = Table::load(Book::class);
+```
+
+
 # static properties
 
 The static relationship properties have changed shape, moving from a flat array to a key-config format:
@@ -237,6 +256,18 @@ class Book extends ActiveRecord
 ```
 
 # other changes
+
+## `Table::update`
+You generally shouldn't be working directly with a `Table` instance, but if you are you should be aware that the `update` method has changed shape:
+```php
+// 1.x 
+$table = Book::table();
+$table->update()
+
+// 2.0
+$table = Table::load(Book::class);
+$table
+```
 
 ## `Config::set_model_directory`
 

--- a/lib/Model.php
+++ b/lib/Model.php
@@ -908,7 +908,7 @@ class Model
      *
      * @return Table
      */
-    public static function table()
+    protected static function table()
     {
         $table = Table::load(get_called_class());
 

--- a/lib/Relationship/AbstractRelationship.php
+++ b/lib/Relationship/AbstractRelationship.php
@@ -157,13 +157,15 @@ abstract class AbstractRelationship
                     $class = $this->options['namespace'] . '\\' . $class;
                 }
 
-                $through_table = $class::table();
+                assert(class_exists($class));
+                $through_table =  Table::load($class);
             } else {
                 $class = $options['class_name'];
                 if (isset($this->options['namespace']) && !class_exists($class)) {
                     $class = $this->options['namespace'] . '\\' . $class;
                 }
-                $relation = $class::table()->get_relationship($options['through']);
+                $relation = Table::load($class)->get_relationship($options['through']);
+                assert(!is_null($relation));
                 $through_table = $relation->get_table();
             }
             $options['joins'] = $this->construct_inner_join_sql($through_table, true);

--- a/lib/Relationship/HasAndBelongsToMany.php
+++ b/lib/Relationship/HasAndBelongsToMany.php
@@ -47,7 +47,7 @@ class HasAndBelongsToMany extends AbstractRelationship
          */
         $rel = new Relation($this->class_name, [], []);
         $rel->from($this->attribute_name);
-        $other_table = $model->table()->table;
+        $other_table = Table::load(get_class($model))->table;
         $rel->where($other_table . '. ' . $this->options['foreign_key'] . ' = ?', $model->{$model->get_primary_key()});
         $rel->joins([$other_table]);
 

--- a/lib/Relationship/HasMany.php
+++ b/lib/Relationship/HasMany.php
@@ -154,7 +154,8 @@ class HasMany extends AbstractRelationship
                 $this->set_keys($this->get_table()->class->getName(), true);
 
                 $class = $this->class_name;
-                $relation = $class::table()->get_relationship($this->through);
+                $relation = Table::load($class)->get_relationship($this->through);
+                assert(!is_null($relation));
                 $through_table = $relation->get_table();
                 $this->options['joins'] = $this->construct_inner_join_sql($through_table, true);
 

--- a/lib/Table.php
+++ b/lib/Table.php
@@ -423,7 +423,7 @@ class Table
 
     /**
      * @param string|Attributes $attributes
-     * @param RelationOptions $options
+     * @param RelationOptions   $options
      *
      * @throws Exception\ActiveRecordException
      */

--- a/lib/Table.php
+++ b/lib/Table.php
@@ -423,7 +423,7 @@ class Table
 
     /**
      * @param string|Attributes $attributes
-     * @param Attributes        $options
+     * @param RelationOptions $options
      *
      * @throws Exception\ActiveRecordException
      */

--- a/test/ActiveRecordCacheTest.php
+++ b/test/ActiveRecordCacheTest.php
@@ -2,6 +2,7 @@
 
 use activerecord\Cache;
 use activerecord\Config;
+use ActiveRecord\Table;
 use test\models\Author;
 
 class ActiveRecordCacheTest extends DatabaseTestCase
@@ -42,7 +43,7 @@ class ActiveRecordCacheTest extends DatabaseTestCase
         static::resetTableData();
         Author::first();
 
-        $table_name = Author::table()->table;
+        $table_name = Table::load(Author::class)->table;
         $value = Cache::$adapter->read("get_meta_data-$table_name");
         $this->assertTrue(is_array($value));
     }

--- a/test/ActiveRecordFindByTest.php
+++ b/test/ActiveRecordFindByTest.php
@@ -4,6 +4,7 @@ namespace test;
 
 use ActiveRecord\Exception\ActiveRecordException;
 use ActiveRecord\Exception\DatabaseException;
+use ActiveRecord\Table;
 use test\models\Author;
 use test\models\Venue;
 
@@ -11,8 +12,8 @@ class ActiveRecordFindByTest extends \DatabaseTestCase
 {
     public function testEscapeQuotes()
     {
-        $author = Author::find_by_name("Tito's");
-        $this->assertNotEquals("Tito's", Author::table()->last_sql);
+        Author::find_by_name("Tito's");
+        $this->assertNotEquals("Tito's", Table::load(Author::class)->last_sql);
     }
 
     public function testFindByWithInvalidFieldName()

--- a/test/ActiveRecordFindTest.php
+++ b/test/ActiveRecordFindTest.php
@@ -3,6 +3,7 @@
 use ActiveRecord\Exception\RecordNotFound;
 use ActiveRecord\Exception\ValidationsArgumentError;
 use ActiveRecord\Model;
+use ActiveRecord\Table;
 use test\models\Author;
 use test\models\HonestLawyer;
 use test\models\JoinBook;
@@ -141,7 +142,7 @@ class ActiveRecordFindTest extends DatabaseTestCase
     {
         $author = Author::order('name')->find(3);
         $this->assertEquals(3, $author->id);
-        $this->assertTrue(false !== strpos(Author::table()->last_sql, 'ORDER BY name'));
+        $this->assertTrue(false !== strpos(Table::load(Author::class)->last_sql, 'ORDER BY name'));
     }
 
     public function testFindByPkArray()
@@ -156,7 +157,7 @@ class ActiveRecordFindTest extends DatabaseTestCase
     {
         $authors = Author::order('name')->find(1, '2');
         $this->assertEquals(2, count($authors));
-        $this->assertTrue(false !== strpos(Author::table()->last_sql, 'ORDER BY name'));
+        $this->assertTrue(false !== strpos(Table::load(Author::class)->last_sql, 'ORDER BY name'));
     }
 
     public function testFindAll()
@@ -281,14 +282,14 @@ class ActiveRecordFindTest extends DatabaseTestCase
             'author'=>true
         ];
         JoinBook::joins(['author', 'LEFT JOIN authors a ON(books.secondary_author_id=a.author_id)'])->first();
-        $this->assert_sql_includes('INNER JOIN authors ON(books.author_id = authors.author_id)', JoinBook::table()->last_sql);
-        $this->assert_sql_includes('LEFT JOIN authors a ON(books.secondary_author_id=a.author_id)', JoinBook::table()->last_sql);
+        $this->assert_sql_includes('INNER JOIN authors ON(books.author_id = authors.author_id)', Table::load(JoinBook::class)->last_sql);
+        $this->assert_sql_includes('LEFT JOIN authors a ON(books.secondary_author_id=a.author_id)', Table::load(JoinBook::class)->last_sql);
     }
 
     public function testJoinsOnModelWithExplicitJoins()
     {
         JoinBook::joins(['LEFT JOIN authors a ON(books.secondary_author_id=a.author_id)'])->first();
-        $this->assert_sql_includes('LEFT JOIN authors a ON(books.secondary_author_id=a.author_id)', JoinBook::table()->last_sql);
+        $this->assert_sql_includes('LEFT JOIN authors a ON(books.secondary_author_id=a.author_id)', Table::load(JoinBook::class)->last_sql);
     }
 
     public function testFindNonExistentPrimaryKey()
@@ -312,7 +313,7 @@ class ActiveRecordFindTest extends DatabaseTestCase
     public function testFindByPkShouldNotUseLimit()
     {
         Author::find(1);
-        $this->assert_sql_includes('SELECT * FROM authors WHERE author_id = ?', Author::table()->last_sql);
+        $this->assert_sql_includes('SELECT * FROM authors WHERE author_id = ?', Table::load(Author::class)->last_sql);
     }
 
     public function testFindsDatetime()

--- a/test/ActiveRecordFirstLastTest.php
+++ b/test/ActiveRecordFirstLastTest.php
@@ -3,6 +3,7 @@
 namespace test;
 
 use ActiveRecord\Exception\UndefinedPropertyException;
+use ActiveRecord\Table;
 use test\models\Author;
 
 class ActiveRecordFirstLastTest extends \DatabaseTestCase
@@ -41,14 +42,14 @@ class ActiveRecordFirstLastTest extends \DatabaseTestCase
     public function testFirstSortsByPkByDefault()
     {
         Author::where(['author_id IN(?)', [1, 2, 3]])->first();
-        $this->assert_sql_includes('ORDER BY author_id ASC', Author::table()->last_sql);
+        $this->assert_sql_includes('ORDER BY author_id ASC', Table::load(Author::class)->last_sql);
     }
 
     public function testFirstSortsBySuppliedOrder()
     {
         Author::order('name')->where(['author_id IN(?)', [1, 2, 3]])->first();
-        $this->assert_sql_includes('ORDER BY name', Author::table()->last_sql);
-        $this->assert_sql_doesnt_has('ORDER BY author_id ASC', Author::table()->last_sql);
+        $this->assert_sql_includes('ORDER BY name', Table::load(Author::class)->last_sql);
+        $this->assert_sql_doesnt_has('ORDER BY author_id ASC', Table::load(Author::class)->last_sql);
     }
 
     public function testFirstNoResults()

--- a/test/ActiveRecordGroupTest.php
+++ b/test/ActiveRecordGroupTest.php
@@ -3,6 +3,7 @@
 namespace test;
 
 use ActiveRecord;
+use ActiveRecord\Table;
 use test\models\Author;
 use test\models\Venue;
 
@@ -41,7 +42,7 @@ class ActiveRecordGroupTest extends \DatabaseTestCase
 
         $venues = $relation->to_a();
         $this->assertTrue(count($venues) > 0);
-        $this->assert_sql_includes('SELECT state FROM venues GROUP BY state HAVING length(state) = 2 ORDER BY state', Venue::table()->last_sql);
+        $this->assert_sql_includes('SELECT state FROM venues GROUP BY state HAVING length(state) = 2 ORDER BY state', ActiveRecord\Table::load(Venue::class)->last_sql);
     }
 
     public function testHaving(): void
@@ -50,6 +51,6 @@ class ActiveRecordGroupTest extends \DatabaseTestCase
             ->group('date(created_at)')
             ->having("date(created_at) > '2009-01-01'")
             ->first();
-        $this->assert_sql_includes("GROUP BY date(created_at) HAVING date(created_at) > '2009-01-01'", Author::table()->last_sql);
+        $this->assert_sql_includes("GROUP BY date(created_at) HAVING date(created_at) > '2009-01-01'", Table::load(Author::class)->last_sql);
     }
 }

--- a/test/ActiveRecordTakeTest.php
+++ b/test/ActiveRecordTakeTest.php
@@ -3,6 +3,7 @@
 namespace test;
 
 use ActiveRecord\Exception\UndefinedPropertyException;
+use ActiveRecord\Table;
 use test\models\Author;
 
 class ActiveRecordTakeTest extends \DatabaseTestCase
@@ -32,14 +33,14 @@ class ActiveRecordTakeTest extends \DatabaseTestCase
     public function testNoImplicitOrder()
     {
         Author::where(['author_id IN(?)', [1, 2, 3]])->take();
-        $this->assert_sql_doesnt_has('ORDER BY', Author::table()->last_sql);
+        $this->assert_sql_doesnt_has('ORDER BY', Table::load(Author::class)->last_sql);
     }
 
     public function testSortsBySuppliedOrder()
     {
         Author::order('name')->where(['author_id IN(?)', [1, 2, 3]])->take();
-        $this->assert_sql_includes('ORDER BY name', Author::table()->last_sql);
-        $this->assert_sql_doesnt_has('ORDER BY author_id ASC', Author::table()->last_sql);
+        $this->assert_sql_includes('ORDER BY name', Table::load(Author::class)->last_sql);
+        $this->assert_sql_doesnt_has('ORDER BY author_id ASC', Table::load(Author::class)->last_sql);
     }
 
     public function testNoResults()

--- a/test/ActiveRecordTest.php
+++ b/test/ActiveRecordTest.php
@@ -4,6 +4,7 @@ use ActiveRecord\Exception\ActiveRecordException;
 use ActiveRecord\Exception\ReadOnlyException;
 use ActiveRecord\Exception\RelationshipException;
 use ActiveRecord\Exception\UndefinedPropertyException;
+use ActiveRecord\Table;
 use test\models\Author;
 use test\models\AwesomePerson;
 use test\models\Book;
@@ -120,8 +121,8 @@ class ActiveRecordTest extends DatabaseTestCase
 
     public function testNamespaceGetsStrippedFromTableName()
     {
-        $model = new \test\models\namespacetest\Book();
-        $this->assertEquals('books', $model->table()->table);
+        new \test\models\namespacetest\Book();
+        $this->assertEquals('books', Table::load(\test\models\namespacetest\Book::class)->table);
     }
 
     public function testNamespaceGetsStrippedFromInferredForeignKey()

--- a/test/ActiveRecordWriteTest.php
+++ b/test/ActiveRecordWriteTest.php
@@ -104,9 +104,9 @@ class ActiveRecordWriteTest extends DatabaseTestCase
     public function testSequenceWasExplicitlySet()
     {
         if (ConnectionManager::get_connection()->supports_sequences()) {
-            $this->assertEquals(AuthorExplicitSequence::$sequence, AuthorExplicitSequence::table()->sequence);
+            $this->assertEquals(AuthorExplicitSequence::$sequence, Table::load(AuthorExplicitSequence::class)->sequence);
         } else {
-            $this->assertNull(Author::table()->sequence);
+            $this->assertNull(Table::load(Author::class)->sequence);
         }
     }
 
@@ -220,8 +220,8 @@ class ActiveRecordWriteTest extends DatabaseTestCase
     public function testDirtyAttributesClearedAfterSaving()
     {
         $book = $this->make_new_book_and();
-        $this->assertTrue(false !== strpos($book->table()->last_sql, 'name'));
-        $this->assertTrue(false !== strpos($book->table()->last_sql, 'special'));
+        $this->assertTrue(false !== strpos(Table::load(Book::class)->last_sql, 'name'));
+        $this->assertTrue(false !== strpos(Table::load(Book::class)->last_sql, 'special'));
         $this->assertEquals([], $book->dirty_attributes());
     }
 
@@ -304,7 +304,7 @@ class ActiveRecordWriteTest extends DatabaseTestCase
     public function testUpdateWithNoPrimaryKeyDefined()
     {
         $this->expectException(ActiveRecordException::class);
-        Author::table()->pk = [];
+        Table::load(Author::class)->pk = [];
         $author = Author::first();
         $author->name = 'blahhhhhhhhhh';
         $author->save();
@@ -313,7 +313,7 @@ class ActiveRecordWriteTest extends DatabaseTestCase
     public function testDeleteWithNoPrimaryKeyDefined()
     {
         $this->expectException(ActiveRecordException::class);
-        Author::table()->pk = [];
+        Table::load(Author::class)->pk = [];
         $author = author::first();
         $author->delete();
     }
@@ -444,7 +444,7 @@ class ActiveRecordWriteTest extends DatabaseTestCase
             ->update_all('parent_author_id = 2');
 
         $this->assertEquals(1, $num_affected);
-        $this->assertTrue(false !== strpos(Author::table()->last_sql, 'ORDER BY name asc LIMIT 1'));
+        $this->assertTrue(false !== strpos(Table::load(Author::class)->last_sql, 'ORDER BY name asc LIMIT 1'));
     }
 
     public function testUpdateNativeDatetime()

--- a/test/CacheModelTest.php
+++ b/test/CacheModelTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use ActiveRecord\Cache;
+use ActiveRecord\Table;
 use test\models\Author;
 use test\models\Publisher;
 
@@ -37,12 +38,12 @@ class CacheModelTest extends DatabaseTestCase
 
     public function testDefaultExpire()
     {
-        $this->assertEquals(30, Author::table()->cache_model_expire);
+        $this->assertEquals(30, Table::load(Author::class)->cache_model_expire);
     }
 
     public function testExplicitExpire()
     {
-        $this->assertEquals(2592000, Publisher::table()->cache_model_expire);
+        $this->assertEquals(2592000, Table::load(Publisher::class)->cache_model_expire);
     }
 
     public function testCacheKey()

--- a/test/ModelCallbackTest.php
+++ b/test/ModelCallbackTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use ActiveRecord\Table;
 use test\models\Venue;
 
 class ModelCallbackTest extends DatabaseTestCase
@@ -12,7 +13,7 @@ class ModelCallbackTest extends DatabaseTestCase
         parent::setUp($connection_name);
 
         $this->venue = new Venue();
-        $this->callback = Venue::table()->callback;
+        $this->callback = Table::load(Venue::class)->callback;
     }
 
     public function register_and_invoke_callbacks($callbacks, $return, $closure)

--- a/test/PgsqlAdapterTest.php
+++ b/test/PgsqlAdapterTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use ActiveRecord\ConnectionManager;
+use ActiveRecord\Table;
 use test\models\Author;
 
 class PgsqlAdapterTest extends AdapterTestCase
@@ -19,9 +20,10 @@ class PgsqlAdapterTest extends AdapterTestCase
 
     public function testSequenceWasSet()
     {
+        $table = Table::load(Author::class);
         $this->assertEquals(
-            ConnectionManager::get_connection()->init_sequence_name(Author::table()),
-            Author::table()->sequence
+            ConnectionManager::get_connection()->init_sequence_name($table),
+            $table->sequence
         );
     }
 


### PR DESCRIPTION
I was integrating the latest RC into my client code, and managed to nuke an entire table. The culprit was the refactoring I did on `Table`. I don't believe that `Table` was ever really meant to be part of the public API, so rather than undo the refactor, I'm opting to make `Model::table` protected.