### PR TITLE
fix pk usage

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "keywords": ["activerecord", "orm"],
     "homepage": "http://www.phpactiverecord.org/",
     "license": "MIT",
-    "version": "2.0.1",
+    "version": "2.0.2",
     "require": {
         "php": ">=8.1.0"
     },

--- a/lib/Model.php
+++ b/lib/Model.php
@@ -1112,7 +1112,7 @@ class Model
 
         $options = [
             'conditions' => [
-                new WhereClause([$this->table()->pk[0] => $pk], [])
+                new WhereClause($pk, [])
             ]
         ];
 


### PR DESCRIPTION
`Model::delete` was implemented in such a way that multiple primary keys were not being considered when constructing its where, which led to deleting more than was intended. Whoops.