### PR TITLE
Port to PHP 8.4

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   phpstan:
     name: PHPStan
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
 
@@ -23,7 +23,7 @@ jobs:
         with:
           coverage: pcov
           ini-values: zend.assertions=1, assert.exception=1
-          php-version: 8.1
+          php-version: 8.4
           extensions: memcached
           tools: cs2pr
 

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   phpcsfixer:
     name: PHP CS Fixer
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
 
@@ -23,7 +23,7 @@ jobs:
         with:
           coverage: pcov
           ini-values: zend.assertions=1, assert.exception=1
-          php-version: 8.1
+          php-version: 8.4
           extensions: memcached
           tools: cs2pr
 

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           coverage: pcov
           ini-values: zend.assertions=1, assert.exception=1
-          php-version: 8.4
+          php-version: 8.3
           extensions: memcached
           tools: cs2pr
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   phpunit:
     name: PHPUnit
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     services:
       memcached:
         image: memcached:1.6
@@ -47,6 +47,8 @@ jobs:
         php-version:
           - 8.1
           - 8.2
+          - 8.3
+          - 8.4
         database:
           - mysql
           - pgsql

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         "php": ">=8.1.0"
     },
     "require-dev": {
-      "phpstan/phpstan": "^1.10",
+      "phpstan/phpstan": "1.12.23",
       "phpstan/phpstan-phpunit": "^1.3",
       "phpunit/phpunit": "^10",
       "friendsofphp/php-cs-fixer": "^v3.23.0",

--- a/lib/Adapter/MysqlAdapter.php
+++ b/lib/Adapter/MysqlAdapter.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @package ActiveRecord
  */

--- a/lib/Adapter/MysqlAdapter.php
+++ b/lib/Adapter/MysqlAdapter.php
@@ -70,7 +70,7 @@ class MysqlAdapter extends Connection
 
             $c->raw_type = (count($matches) > 0 ? $matches[1] : $column['type']);
 
-            if (count($matches) >= 4) {
+            if (isset($matches[3])) {
                 $c->length = intval($matches[3]);
             }
         }

--- a/lib/Adapter/PgsqlAdapter.php
+++ b/lib/Adapter/PgsqlAdapter.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @package ActiveRecord
  */

--- a/lib/Adapter/PgsqlAdapter.php
+++ b/lib/Adapter/PgsqlAdapter.php
@@ -132,7 +132,7 @@ SQL;
             preg_match('/^([A-Za-z0-9_]+)(\(([0-9]+(,[0-9]+)?)\))?/', $column['type'], $matches);
 
             $c->raw_type = (count($matches) > 0 ? $matches[1] : $column['type']);
-            $c->length = count($matches) >= 4 ? intval($matches[3]) : intval($column['attlen']);
+            $c->length = isset($matches[3]) ? intval($matches[3]) : intval($column['attlen']);
 
             if ($c->length < 0) {
                 $c->length = null;

--- a/lib/Adapter/SqliteAdapter.php
+++ b/lib/Adapter/SqliteAdapter.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @package ActiveRecord
  */

--- a/lib/Cache.php
+++ b/lib/Cache.php
@@ -83,7 +83,7 @@ class Cache
      *
      * @param int $expire in seconds
      */
-    public static function get(string $key, \Closure $closure, int $expire = null): mixed
+    public static function get(string $key, \Closure $closure, ?int $expire = null): mixed
     {
         if (!static::$adapter) {
             return $closure();
@@ -98,7 +98,7 @@ class Cache
         return $value;
     }
 
-    public static function set(string $key, mixed $var, int $expire = null): void
+    public static function set(string $key, mixed $var, ?int $expire = null): void
     {
         assert(isset(static::$adapter), 'Adapter required to set');
 

--- a/lib/CallBack.php
+++ b/lib/CallBack.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @package ActiveRecord
  */
@@ -163,7 +164,7 @@ class CallBack
      *               that was for a before_* callback and that method returned false. If this happens, execution
      *               of any other callbacks after the offending callback will not occur.
      */
-    public function invoke(Model|null $model, string $name, bool $must_exist = true)
+    public function invoke(?Model $model, string $name, bool $must_exist = true)
     {
         if ($must_exist && !array_key_exists($name, $this->registry)) {
             throw new ActiveRecordException("No callbacks were defined for: $name on " . ($model ? get_class($model) : 'null'));
@@ -214,7 +215,7 @@ class CallBack
      *
      * @throws ActiveRecordException if invalid callback type or callback method was not found
      */
-    public function register(string $name, \Closure|string $closure_or_method_name = null, array $options = []): void
+    public function register(string $name, \Closure|string|null $closure_or_method_name = null, array $options = []): void
     {
         $closure_or_method_name ??= $name;
 

--- a/lib/Column.php
+++ b/lib/Column.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @package ActiveRecord
  */
@@ -66,7 +67,7 @@ class Column
     /**
      * The maximum length of this column.
      */
-    public int|null $length = null;
+    public ?int $length = null;
 
     /**
      * True if this column allows null.

--- a/lib/Config.php
+++ b/lib/Config.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @package ActiveRecord
  */
@@ -202,7 +203,7 @@ class Config extends Singleton
     /**
      * Returns the logger
      */
-    public function get_logger(): LoggerInterface|null
+    public function get_logger(): ?LoggerInterface
     {
         return $this->logger ?? null;
     }

--- a/lib/Connection.php
+++ b/lib/Connection.php
@@ -50,7 +50,7 @@ abstract class Connection
     /**
      * Contains a Logger object that must implement a log() method.
      */
-    private LoggerInterface|null $logger;
+    private ?LoggerInterface $logger;
     /**
      * The name of the protocol that is used.
      */
@@ -105,7 +105,7 @@ abstract class Connection
      *
      * @see parse_connection_url
      */
-    public static function instance(string $connection_string_or_connection_name = null)
+    public static function instance(?string $connection_string_or_connection_name = null)
     {
         $config = Config::instance();
 

--- a/lib/ConnectionManager.php
+++ b/lib/ConnectionManager.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @package ActiveRecord
  */
@@ -28,7 +29,7 @@ class ConnectionManager extends Singleton
      *
      * @return Connection
      */
-    public static function get_connection(string $name=null)
+    public static function get_connection(?string $name=null)
     {
         $config = Config::instance();
         $name = $name ?? $config->get_default_connection();

--- a/lib/DateTime.php
+++ b/lib/DateTime.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @package ActiveRecord
  */
@@ -67,8 +68,8 @@ final class DateTime extends \DateTime implements DateTimeInterface
         'rss'     => \DateTime::RSS,
         'w3c'     => \DateTime::W3C];
 
-    private Model|null $model = null;
-    private string|null $attribute_name = null;
+    private ?Model $model = null;
+    private ?string $attribute_name = null;
 
     public function attribute_of(Model $model, string $attribute_name): void
     {
@@ -109,7 +110,7 @@ final class DateTime extends \DateTime implements DateTimeInterface
      *
      * @return string a format string
      */
-    public static function get_format(string $format = null): string
+    public static function get_format(?string $format = null): string
     {
         // use default format if no format specified
         if (!$format) {
@@ -129,7 +130,7 @@ final class DateTime extends \DateTime implements DateTimeInterface
      * This needs to be overridden so it returns an instance of this class instead of PHP's \DateTime.
      * See http://php.net/manual/en/datetime.createfromformat.php
      */
-    public static function createFromFormat(string $format, string $time, \DateTimeZone $timezone = null): static
+    public static function createFromFormat(string $format, string $time, ?\DateTimeZone $timezone = null): static
     {
         $phpDate = parent::createFromFormat($format, $time, $timezone);
         assert($phpDate);

--- a/lib/DateTimeInterface.php
+++ b/lib/DateTimeInterface.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @package ActiveRecord
  */
@@ -29,5 +30,5 @@ interface DateTimeInterface
     /**
      * See http://php.net/manual/en/datetime.createfromformat.php
      */
-    public static function createFromFormat(string $format, string $time, \DateTimeZone $timezone = null): static;
+    public static function createFromFormat(string $format, string $time, ?\DateTimeZone $timezone = null): static;
 }

--- a/lib/Exception/DatabaseException.php
+++ b/lib/Exception/DatabaseException.php
@@ -11,7 +11,7 @@ namespace ActiveRecord\Exception;
  */
 class DatabaseException extends ActiveRecordException
 {
-    public function __construct(string $message = '', int $code = 0, \Throwable $previous = null)
+    public function __construct(string $message = '', int $code = 0, ?\Throwable $previous = null)
     {
         parent::__construct($message, $code, $previous);
     }

--- a/lib/Inflector.php
+++ b/lib/Inflector.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @package ActiveRecord
  */

--- a/lib/Model.php
+++ b/lib/Model.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * The base class for your models.
  *
@@ -836,7 +837,7 @@ class Model
      * @param string          $name     Name of an attribute
      * @param DelegateOptions $delegate An array containing delegate data
      */
-    private function is_delegated(string $name, array $delegate): string|null
+    private function is_delegated(string $name, array $delegate): ?string
     {
         if (is_array($delegate)) {
             if (!empty($delegate['prefix'])) {
@@ -1403,7 +1404,7 @@ class Model
      *
      * @see Relation::__call()
      */
-    public static function __callStatic(string $method, mixed $args): static|null
+    public static function __callStatic(string $method, mixed $args): ?static
     {
         return static::Relation()->$method(...$args);
     }
@@ -1674,7 +1675,7 @@ class Model
      *
      * @return static|array<static>|null
      */
-    public static function take(int $limit = null): static|array|null
+    public static function take(?int $limit = null): static|array|null
     {
         return static::Relation()->take($limit);
     }
@@ -1684,7 +1685,7 @@ class Model
      *
      * @return static|array<static>|null
      */
-    public static function first(int $limit = null): static|array|null
+    public static function first(?int $limit = null): static|array|null
     {
         return static::Relation()->first($limit);
     }
@@ -1694,7 +1695,7 @@ class Model
      *
      * @return static|array<static>|null
      */
-    public static function last(int $limit = null): static|array|null
+    public static function last(?int $limit = null): static|array|null
     {
         return static::Relation()->last($limit);
     }

--- a/lib/Reflections.php
+++ b/lib/Reflections.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @package ActiveRecord
  */

--- a/lib/Relation.php
+++ b/lib/Relation.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Interface
  *
@@ -147,7 +148,7 @@ class Relation implements \Iterator
      *
      * @return Model|null The first model that meets the find by criteria, or null if no row meets that criteria
      */
-    public function __call(string $method, mixed $args): Model|null
+    public function __call(string $method, mixed $args): ?Model
     {
         $create = false;
 
@@ -778,7 +779,7 @@ class Relation implements \Iterator
      *
      * @return TModel|array<TModel>|null
      */
-    public function take(int $limit = null): Model|array|null
+    public function take(?int $limit = null): Model|array|null
     {
         $options = array_merge($this->options, ['limit' => $limit ?? 1]);
         $models = $this->_to_a($options);
@@ -798,7 +799,7 @@ class Relation implements \Iterator
      *
      * @return TModel|array<TModel>|null
      */
-    public function first(int $limit = null): Model|array|null
+    public function first(?int $limit = null): Model|array|null
     {
         $models = $this->firstOrLast($limit, true);
 
@@ -819,7 +820,7 @@ class Relation implements \Iterator
      *
      * @return TModel|array<TModel>|null
      */
-    public function last(int $limit = null): Model|array|null
+    public function last(?int $limit = null): Model|array|null
     {
         $models = $this->firstOrLast($limit, false);
 
@@ -849,7 +850,7 @@ class Relation implements \Iterator
     /**
      * @return array<TModel>
      */
-    private function firstOrLast(int $limit = null, bool $isAscending): array
+    private function firstOrLast(?int $limit = null, bool $isAscending): array
     {
         $options = array_merge($this->options, ['limit' => $limit ?? 1]);
 
@@ -1083,7 +1084,7 @@ class Relation implements \Iterator
      *   'name' => 'Oscar'      // WHERE "users"."name" = 'Oscar'
      * ])->to_sql()
      *
-     * @throws Exception\ActiveRecordException
+     * @throws ActiveRecordException
      * @throws Exception\RelationshipException
      */
     public function to_sql(): string

--- a/lib/Relation.php
+++ b/lib/Relation.php
@@ -850,7 +850,7 @@ class Relation implements \Iterator
     /**
      * @return array<TModel>
      */
-    private function firstOrLast(?int $limit = null, bool $isAscending): array
+    private function firstOrLast(?int $limit = null, bool $isAscending = true): array
     {
         $options = array_merge($this->options, ['limit' => $limit ?? 1]);
 

--- a/lib/Relationship/AbstractRelationship.php
+++ b/lib/Relationship/AbstractRelationship.php
@@ -344,7 +344,7 @@ abstract class AbstractRelationship
      *
      * @return string SQL INNER JOIN fragment
      */
-    public function construct_inner_join_sql(Table $from_table, bool $using_through = false, string $alias = null)
+    public function construct_inner_join_sql(Table $from_table, bool $using_through = false, ?string $alias = null)
     {
         if ($using_through) {
             $join_table_name = $from_table->get_fully_qualified_table_name();

--- a/lib/Relationship/HasAndBelongsToMany.php
+++ b/lib/Relationship/HasAndBelongsToMany.php
@@ -62,7 +62,7 @@ class HasAndBelongsToMany extends AbstractRelationship
         return implode('_', $parts);
     }
 
-    public function construct_inner_join_sql(Table $from_table, bool $using_through = false, string $alias = null): string
+    public function construct_inner_join_sql(Table $from_table, bool $using_through = false, ?string $alias = null): string
     {
         $other_table = Table::load($this->class_name);
         $associated_table_name = $other_table->table;

--- a/lib/SQLBuilder.php
+++ b/lib/SQLBuilder.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @package ActiveRecord
  */
@@ -200,7 +201,7 @@ class SQLBuilder
      *
      * @return $this
      */
-    public function insert(array $hash, mixed $pk = null, string $sequence_name = null): static
+    public function insert(array $hash, mixed $pk = null, ?string $sequence_name = null): static
     {
         if (!is_hash($hash)) {
             throw new ActiveRecordException('Inserting requires a hash.');

--- a/lib/Serialize/XmlSerializer.php
+++ b/lib/Serialize/XmlSerializer.php
@@ -57,7 +57,7 @@ class XmlSerializer extends Serialization
     /**
      * @param array<string,mixed> $data
      */
-    private function write(array $data, string $tag = null): void
+    private function write(array $data, ?string $tag = null): void
     {
         foreach ($data as $attr => $value) {
             $attr = $tag ?? $attr;

--- a/lib/Singleton.php
+++ b/lib/Singleton.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @package ActiveRecord
  */

--- a/lib/Table.php
+++ b/lib/Table.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @package ActiveRecord
  */
@@ -102,7 +103,7 @@ class Table
         return self::$cache[$model_class_name];
     }
 
-    public static function clear_cache(string $model_class_name = null): void
+    public static function clear_cache(?string $model_class_name = null): void
     {
         if ($model_class_name && array_key_exists($model_class_name, self::$cache)) {
             unset(self::$cache[$model_class_name]);
@@ -351,7 +352,7 @@ class Table
         }
     }
 
-    public function get_column_by_inflected_name(string $inflected_name): Column|null
+    public function get_column_by_inflected_name(string $inflected_name): ?Column
     {
         foreach ($this->columns as $raw_name => $column) {
             if ($column->inflected_name == $inflected_name) {
@@ -408,7 +409,7 @@ class Table
      *
      * @throws Exception\ActiveRecordException
      */
-    public function insert(array &$data, string|int $pk = null, string $sequence_name = null): \PDOStatement
+    public function insert(array &$data, string|int|null $pk = null, ?string $sequence_name = null): \PDOStatement
     {
         $data = $this->process_data($data);
 

--- a/lib/Utils.php
+++ b/lib/Utils.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @package ActiveRecord
  */
@@ -187,7 +188,7 @@ class Utils
         return (bool) ((int) $number & 1);
     }
 
-    public static function is_blank(string|null $var): bool
+    public static function is_blank(?string $var): bool
     {
         return 0 === strlen($var ?? '');
     }

--- a/lib/ValidationErrors.php
+++ b/lib/ValidationErrors.php
@@ -11,7 +11,7 @@ namespace ActiveRecord;
  */
 class ValidationErrors implements \IteratorAggregate
 {
-    private Model|null $model;
+    private ?Model $model;
 
     /**
      * @var array<string, array<string>>
@@ -170,7 +170,7 @@ class ValidationErrors implements \IteratorAggregate
      *
      * @return array<string, array<string>>
      */
-    public function to_array(callable $closure = null): array
+    public function to_array(?callable $closure = null): array
     {
         $errors = [];
 

--- a/lib/Validations.php
+++ b/lib/Validations.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * These two classes have been <i>heavily borrowed</i> from Ruby on Rails' ActiveRecord so much that
  * this piece can be considered a straight port. The reason for this is that the vaildation process is

--- a/lib/WhereClause.php
+++ b/lib/WhereClause.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @package ActiveRecord
  */
@@ -78,7 +79,7 @@ class WhereClause
      * @throws DatabaseException
      */
     public function to_s(Connection $connection, string $prependTableName = '', array $mappedNames = [],
-        bool $substitute=false, string $glue=' AND ', array $values=null): string
+        bool $substitute=false, string $glue=' AND ', ?array $values=null): string
     {
         $values = $values ?? $this->values;
         $expression = $this->expression;

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -6,8 +6,8 @@ parameters:
         - %currentWorkingDirectory%/test/phpstan
 
     reportUnmatchedIgnoredErrors: false
-    checkGenericClassInNonGenericObjectType: false
     ignoreErrors:
+      - identifier: missingType.generics
 
 includes:
   - extension.neon

--- a/scripts/TestCommand.php
+++ b/scripts/TestCommand.php
@@ -47,7 +47,7 @@ class TestCommand
         }
     }
 
-    private static function buildArgs(string|null $fileName, string|null $filter): array
+    private static function buildArgs(?string $fileName, ?string $filter): array
     {
         $args = ['vendor/bin/phpunit'];
 

--- a/test/ActiveRecordFindTest.php
+++ b/test/ActiveRecordFindTest.php
@@ -189,13 +189,13 @@ class ActiveRecordFindTest extends DatabaseTestCase
 
     public function testFindAllHash()
     {
-        $books = \test\models\Book::all()->where(['author_id' => 1])->to_a();
+        $books = test\models\Book::all()->where(['author_id' => 1])->to_a();
         $this->assertTrue(count($books) > 0);
     }
 
     public function testFindAllHashWithOrder()
     {
-        $books = \test\models\Book::order('name DESC')->where(['author_id' => 1])->to_a();
+        $books = test\models\Book::order('name DESC')->where(['author_id' => 1])->to_a();
         $this->assertTrue(count($books) > 0);
     }
 
@@ -259,7 +259,7 @@ class ActiveRecordFindTest extends DatabaseTestCase
         $res = Author::all()->to_a();
 
         foreach ($res as $author) {
-            $this->assertTrue($author instanceof ActiveRecord\Model);
+            $this->assertTrue($author instanceof Model);
             ++$i;
         }
         $this->assertTrue($i > 0);
@@ -270,7 +270,7 @@ class ActiveRecordFindTest extends DatabaseTestCase
         $i = 0;
 
         foreach (Author::all()->to_a() as $author) {
-            $this->assertTrue($author instanceof ActiveRecord\Model);
+            $this->assertTrue($author instanceof Model);
             ++$i;
         }
         $this->assertTrue($i > 0);

--- a/test/ActiveRecordGroupTest.php
+++ b/test/ActiveRecordGroupTest.php
@@ -2,7 +2,6 @@
 
 namespace test;
 
-use ActiveRecord;
 use ActiveRecord\Table;
 use test\models\Author;
 use test\models\Venue;
@@ -13,7 +12,7 @@ class ActiveRecordGroupTest extends \DatabaseTestCase
     {
         $venues = Venue::select('state')->group('state')->to_a();
         $this->assertTrue(count($venues) > 0);
-        $this->assert_sql_includes('GROUP BY state', ActiveRecord\Table::load(Venue::class)->last_sql);
+        $this->assert_sql_includes('GROUP BY state', Table::load(Venue::class)->last_sql);
     }
 
     public function testWithArray(): void
@@ -21,7 +20,7 @@ class ActiveRecordGroupTest extends \DatabaseTestCase
         $venues = Venue::select(['city', 'state'])->group(['city', 'state'])->to_a();
         $this->assertTrue(count($venues) > 0);
 
-        $this->assert_sql_includes('GROUP BY city, state', ActiveRecord\Table::load(Venue::class)->last_sql);
+        $this->assert_sql_includes('GROUP BY city, state', Table::load(Venue::class)->last_sql);
     }
 
     public function testWithList(): void
@@ -29,7 +28,7 @@ class ActiveRecordGroupTest extends \DatabaseTestCase
         $venues = Venue::select('city', 'state')->group('city', 'state')->to_a();
         $this->assertTrue(count($venues) > 0);
 
-        $this->assert_sql_includes('GROUP BY city, state', ActiveRecord\Table::load(Venue::class)->last_sql);
+        $this->assert_sql_includes('GROUP BY city, state', Table::load(Venue::class)->last_sql);
     }
 
     public function testGroupWithOrderAndLimitAndHaving(): void
@@ -42,7 +41,7 @@ class ActiveRecordGroupTest extends \DatabaseTestCase
 
         $venues = $relation->to_a();
         $this->assertTrue(count($venues) > 0);
-        $this->assert_sql_includes('SELECT state FROM venues GROUP BY state HAVING length(state) = 2 ORDER BY state', ActiveRecord\Table::load(Venue::class)->last_sql);
+        $this->assert_sql_includes('SELECT state FROM venues GROUP BY state HAVING length(state) = 2 ORDER BY state', Table::load(Venue::class)->last_sql);
     }
 
     public function testHaving(): void

--- a/test/ActiveRecordNotTest.php
+++ b/test/ActiveRecordNotTest.php
@@ -15,20 +15,20 @@ class ActiveRecordNotTest extends \DatabaseTestCase
             ],
             'array' => [
                 [
-                  'name = ?', 'Another Book',
+                    'name = ?', 'Another Book',
                 ],
                 static fn ($book) => 'AnotherBook' != $book->name
             ],
             'hash' => [[
-                    'name' => 'Another Book',
-                ],
+                'name' => 'Another Book',
+            ],
                 static fn ($book) => 'AnotherBook' != $book->name
             ],
             'in' => [[
                 'book_id in (?)', [1, 2],
-              ],
-              static fn ($book) => 1 != $book->name && 2 != $book->name
-           ],
+            ],
+                static fn ($book) => 1 != $book->name && 2 != $book->name
+            ],
         ];
     }
 

--- a/test/ActiveRecordTest.php
+++ b/test/ActiveRecordTest.php
@@ -121,14 +121,14 @@ class ActiveRecordTest extends DatabaseTestCase
 
     public function testNamespaceGetsStrippedFromTableName()
     {
-        new \test\models\namespacetest\Book();
-        $this->assertEquals('books', Table::load(\test\models\namespacetest\Book::class)->table);
+        new test\models\namespacetest\Book();
+        $this->assertEquals('books', Table::load(test\models\namespacetest\Book::class)->table);
     }
 
     public function testNamespaceGetsStrippedFromInferredForeignKey()
     {
-        $model = new \test\models\namespacetest\Book();
-        $table = ActiveRecord\Table::load(get_class($model));
+        $model = new test\models\namespacetest\Book();
+        $table = Table::load(get_class($model));
 
         $this->assertEquals($table->get_relationship('parent_book')->foreign_key[0], 'book_id');
         $this->assertEquals($table->get_relationship('parent_book_2')->foreign_key[0], 'book_id');
@@ -137,8 +137,8 @@ class ActiveRecordTest extends DatabaseTestCase
 
     public function testNamespacedRelationshipAssociatesCorrectly()
     {
-        $model = new \test\models\namespacetest\Book();
-        $table = ActiveRecord\Table::load(get_class($model));
+        $model = new test\models\namespacetest\Book();
+        $table = Table::load(get_class($model));
 
         $this->assertNotNull($table->get_relationship('parent_book'));
         $this->assertNotNull($table->get_relationship('parent_book_2'));
@@ -266,7 +266,7 @@ class ActiveRecordTest extends DatabaseTestCase
 
     public function testCastWhenLoading()
     {
-        $book = \test\models\Book::find(1);
+        $book = Book::find(1);
         $this->assertSame(1, $book->book_id);
         $this->assertSame('Ancient Art of Main Tanking', $book->name);
     }
@@ -400,10 +400,10 @@ class ActiveRecordTest extends DatabaseTestCase
 
     public function testClearCacheForSpecificClass()
     {
-        $book_table1 = ActiveRecord\Table::load(Book::class);
-        $book_table2 = ActiveRecord\Table::load(Book::class);
-        ActiveRecord\Table::clear_cache('Book');
-        $book_table3 = ActiveRecord\Table::load(Book::class);
+        $book_table1 = Table::load(Book::class);
+        $book_table2 = Table::load(Book::class);
+        Table::clear_cache('Book');
+        $book_table3 = Table::load(Book::class);
 
         $this->assertTrue($book_table1 === $book_table2);
         $this->assertTrue($book_table1 !== $book_table3);
@@ -437,7 +437,7 @@ class ActiveRecordTest extends DatabaseTestCase
     public function testAssigningPhpDatetimeGetsConvertedToDateClassWithDefaults()
     {
         $author = new Author();
-        $author->created_at = $now = new \DateTime();
+        $author->created_at = $now = new DateTime();
         $this->assertInstanceOf('ActiveRecord\\DateTime', $author->created_at);
         $this->assertEquals($now->format(DateTime::ATOM), $author->created_at->format(DateTime::ATOM));
     }
@@ -446,14 +446,14 @@ class ActiveRecordTest extends DatabaseTestCase
     {
         ActiveRecord\Config::instance()->set_date_class('\\DateTime'); // use PHP built-in DateTime
         $author = new Author();
-        $author->created_at = $now = new \DateTime();
+        $author->created_at = $now = new DateTime();
         $this->assertInstanceOf('DateTime', $author->created_at);
         $this->assertEquals($now->format(DateTime::ATOM), $author->created_at->format(DateTime::ATOM));
     }
 
     public function testAssigningFromMassAssignmentPhpDatetimeGetsConvertedToArDatetime()
     {
-        $author = new Author(['created_at' => new \DateTime()]);
+        $author = new Author(['created_at' => new DateTime()]);
         $this->assertInstanceOf('ActiveRecord\\DateTime', $author->created_at);
     }
 

--- a/test/ActiveRecordWriteTest.php
+++ b/test/ActiveRecordWriteTest.php
@@ -36,7 +36,7 @@ class AuthorExplicitSequence extends ActiveRecord\Model
 
 class ActiveRecordWriteTest extends DatabaseTestCase
 {
-    public function setUp(string $connection_name=null): void
+    public function setUp(?string $connection_name=null): void
     {
         parent::setUp($connection_name);
         static::resetTableData();
@@ -314,7 +314,7 @@ class ActiveRecordWriteTest extends DatabaseTestCase
     {
         $this->expectException(ActiveRecordException::class);
         Table::load(Author::class)->pk = [];
-        $author = author::first();
+        $author = Author::first();
         $author->delete();
     }
 

--- a/test/CacheModelTest.php
+++ b/test/CacheModelTest.php
@@ -67,7 +67,7 @@ class CacheModelTest extends DatabaseTestCase
     public function testModelCacheNew()
     {
         $publisher = new Publisher([
-           'name'=>'HarperCollins'
+            'name'=>'HarperCollins'
         ]);
         $publisher->save();
 

--- a/test/ColumnTest.php
+++ b/test/ColumnTest.php
@@ -130,7 +130,7 @@ class ColumnTest extends DatabaseTestCase
 
     public function testNativeDateTimeAttributeCopiesExactTz()
     {
-        $dt = new \DateTime('', new \DateTimeZone('America/New_York'));
+        $dt = new \DateTime('', new DateTimeZone('America/New_York'));
 
         $column = new Column();
         $column->type = Column::DATETIME;
@@ -144,7 +144,7 @@ class ColumnTest extends DatabaseTestCase
 
     public function testArDateTimeAttributeCopiesExactTz()
     {
-        $dt = new DateTime('', new \DateTimeZone('America/New_York'));
+        $dt = new DateTime('', new DateTimeZone('America/New_York'));
 
         $column = new Column();
         $column->type = Column::DATETIME;

--- a/test/ConfigTest.php
+++ b/test/ConfigTest.php
@@ -8,7 +8,7 @@ use Psr\Log\LoggerInterface;
 
 class TestLogger implements LoggerInterface
 {
-    public function emergency(string|\Stringable $message, array $context = []): void
+    public function emergency(string|Stringable $message, array $context = []): void
     {
     }
 
@@ -20,7 +20,7 @@ class TestLogger implements LoggerInterface
      *
      * @param mixed[] $context
      */
-    public function alert(string|\Stringable $message, array $context = []): void
+    public function alert(string|Stringable $message, array $context = []): void
     {
     }
 
@@ -31,7 +31,7 @@ class TestLogger implements LoggerInterface
      *
      * @param mixed[] $context
      */
-    public function critical(string|\Stringable $message, array $context = []): void
+    public function critical(string|Stringable $message, array $context = []): void
     {
     }
 
@@ -41,7 +41,7 @@ class TestLogger implements LoggerInterface
      *
      * @param mixed[] $context
      */
-    public function error(string|\Stringable $message, array $context = []): void
+    public function error(string|Stringable $message, array $context = []): void
     {
     }
 
@@ -53,7 +53,7 @@ class TestLogger implements LoggerInterface
      *
      * @param mixed[] $context
      */
-    public function warning(string|\Stringable $message, array $context = []): void
+    public function warning(string|Stringable $message, array $context = []): void
     {
     }
 
@@ -62,7 +62,7 @@ class TestLogger implements LoggerInterface
      *
      * @param mixed[] $context
      */
-    public function notice(string|\Stringable $message, array $context = []): void
+    public function notice(string|Stringable $message, array $context = []): void
     {
     }
 
@@ -73,7 +73,7 @@ class TestLogger implements LoggerInterface
      *
      * @param mixed[] $context
      */
-    public function info(string|\Stringable $message, array $context = []): void
+    public function info(string|Stringable $message, array $context = []): void
     {
     }
 
@@ -82,7 +82,7 @@ class TestLogger implements LoggerInterface
      *
      * @param mixed[] $context
      */
-    public function debug(string|\Stringable $message, array $context = []): void
+    public function debug(string|Stringable $message, array $context = []): void
     {
     }
 
@@ -91,9 +91,9 @@ class TestLogger implements LoggerInterface
      *
      * @param mixed[] $context
      *
-     * @throws \Psr\Log\InvalidArgumentException
+     * @throws Psr\Log\InvalidArgumentException
      */
-    public function log($level, string|\Stringable $message, array $context = []): void
+    public function log($level, string|Stringable $message, array $context = []): void
     {
     }
 }

--- a/test/ConnectionTest.php
+++ b/test/ConnectionTest.php
@@ -12,12 +12,12 @@ class ConnectionTest extends TestCase
     public function testConnectionInfoFromShouldThrowExceptionWhenNoHost()
     {
         $this->expectException(DatabaseException::class);
-        ActiveRecord\Connection::parse_connection_url('mysql://user:pass@');
+        Connection::parse_connection_url('mysql://user:pass@');
     }
 
     public function testConnectionInfo()
     {
-        $info = ActiveRecord\Connection::parse_connection_url('mysql://user:pass@127.0.0.1:3306/dbname');
+        $info = Connection::parse_connection_url('mysql://user:pass@127.0.0.1:3306/dbname');
         $this->assertEquals('mysql', $info['protocol']);
         $this->assertEquals('user', $info['user']);
         $this->assertEquals('pass', $info['pass']);
@@ -28,37 +28,37 @@ class ConnectionTest extends TestCase
 
     public function testGh103SqliteConnectionStringRelative()
     {
-        $info = ActiveRecord\Connection::parse_connection_url('sqlite://../some/path/to/file.db');
+        $info = Connection::parse_connection_url('sqlite://../some/path/to/file.db');
         $this->assertEquals('../some/path/to/file.db', $info['host']);
     }
 
     public function testGh103SqliteConnectionStringAbsolute()
     {
         $this->expectException(DatabaseException::class);
-        ActiveRecord\Connection::parse_connection_url('sqlite:///some/path/to/file.db');
+        Connection::parse_connection_url('sqlite:///some/path/to/file.db');
     }
 
     public function testGh103SqliteConnectionStringUnix()
     {
-        $info = ActiveRecord\Connection::parse_connection_url('sqlite://unix(/some/path/to/file.db)');
+        $info = Connection::parse_connection_url('sqlite://unix(/some/path/to/file.db)');
         $this->assertEquals('/some/path/to/file.db', $info['host']);
 
-        $info = ActiveRecord\Connection::parse_connection_url('sqlite://unix(/some/path/to/file.db)/');
+        $info = Connection::parse_connection_url('sqlite://unix(/some/path/to/file.db)/');
         $this->assertEquals('/some/path/to/file.db', $info['host']);
 
-        $info = ActiveRecord\Connection::parse_connection_url('sqlite://unix(/some/path/to/file.db)/dummy');
+        $info = Connection::parse_connection_url('sqlite://unix(/some/path/to/file.db)/dummy');
         $this->assertEquals('/some/path/to/file.db', $info['host']);
     }
 
     public function testGh103SqliteConnectionStringWindows()
     {
-        $info = ActiveRecord\Connection::parse_connection_url('sqlite://windows(c%3A/some/path/to/file.db)');
+        $info = Connection::parse_connection_url('sqlite://windows(c%3A/some/path/to/file.db)');
         $this->assertEquals('c:/some/path/to/file.db', $info['host']);
     }
 
     public function testParseConnectionUrlWithUnixSockets()
     {
-        $info = ActiveRecord\Connection::parse_connection_url('mysql://user:password@unix(/tmp/mysql.sock)/database');
+        $info = Connection::parse_connection_url('mysql://user:password@unix(/tmp/mysql.sock)/database');
         $this->assertEquals('/tmp/mysql.sock', $info['host']);
 
         $dsn = Connection::data_source_name($info);
@@ -67,20 +67,20 @@ class ConnectionTest extends TestCase
 
     public function testParseConnectionUrlWithDecodeOption()
     {
-        $info = ActiveRecord\Connection::parse_connection_url('mysql://h%20az:h%40i@127.0.0.1/test?decode=true');
+        $info = Connection::parse_connection_url('mysql://h%20az:h%40i@127.0.0.1/test?decode=true');
         $this->assertEquals('h az', $info['user']);
         $this->assertEquals('h@i', $info['pass']);
     }
 
     public function testEncoding()
     {
-        $info = ActiveRecord\Connection::parse_connection_url('mysql://test:test@127.0.0.1/test?charset=utf8');
+        $info = Connection::parse_connection_url('mysql://test:test@127.0.0.1/test?charset=utf8');
         $this->assertEquals('utf8', $info['charset']);
     }
 
     public function testReestablishConnection()
     {
-        $connection = \test\models\Book::reestablish_connection(true);
+        $connection = test\models\Book::reestablish_connection(true);
         $this->assertNotNull($connection);
     }
 }

--- a/test/DateTimeTest.php
+++ b/test/DateTimeTest.php
@@ -158,7 +158,7 @@ class DateTimeTest extends TestCase
 
     public function testCreateFromFormatWithTz()
     {
-        $d = DateTime::createFromFormat('Y-m-d H:i:s', '2000-02-01 03:04:05', new \DateTimeZone('Etc/GMT-10'));
+        $d = DateTime::createFromFormat('Y-m-d H:i:s', '2000-02-01 03:04:05', new DateTimeZone('Etc/GMT-10'));
         $d2 = new DateTime('2000-01-31 17:04:05');
 
         $this->assertEquals($d2->getTimestamp(), $d->getTimestamp());
@@ -166,7 +166,7 @@ class DateTimeTest extends TestCase
 
     public function testNativeDateTimeAttributeCopiesExactTz()
     {
-        $dt = new \DateTime('', new \DateTimeZone('America/New_York'));
+        $dt = new \DateTime('', new DateTimeZone('America/New_York'));
         $model = $this->get_model();
 
         // Test that the data transforms without modification
@@ -180,7 +180,7 @@ class DateTimeTest extends TestCase
 
     public function testArDateTimeAttributeCopiesExactTz()
     {
-        $dt = new DateTime('', new \DateTimeZone('America/New_York'));
+        $dt = new DateTime('', new DateTimeZone('America/New_York'));
         $model = $this->get_model();
 
         // Test that the data transforms without modification

--- a/test/MysqlAdapterTest.php
+++ b/test/MysqlAdapterTest.php
@@ -22,10 +22,10 @@ class MysqlAdapterTest extends AdapterTestCase
     public function testValidatesUniquenessOfWorksWithMysqlReservedWordAsColumnName()
     {
         ValueStoreValidations::create(['key' => 'GA_KEY', 'value' => 'UA-1234567-1']);
-        $valuestore = ValuestoreValidations::create(['key' => 'GA_KEY', 'value' => 'UA-1234567-2']);
+        $valuestore = ValueStoreValidations::create(['key' => 'GA_KEY', 'value' => 'UA-1234567-2']);
 
         $this->assertEquals(['Key must be unique'], $valuestore->errors->full_messages());
-        $this->assertEquals(1, ValuestoreValidations::where('`key`= ?', 'GA_KEY')->count());
+        $this->assertEquals(1, ValueStoreValidations::where('`key`= ?', 'GA_KEY')->count());
     }
 
     public function testEnum()

--- a/test/PgsqlAdapterTest.php
+++ b/test/PgsqlAdapterTest.php
@@ -31,7 +31,7 @@ class PgsqlAdapterTest extends AdapterTestCase
     {
         $this->assert_sql_includes(
             'SELECT * FROM authors WHERE "mixedCaseField" = ? ORDER BY name',
-            \test\models\Author::where('mixedCaseField = ?', 'The Art of Main Tanking')
+            Author::where('mixedCaseField = ?', 'The Art of Main Tanking')
                 ->order('name')->to_sql()
         );
     }

--- a/test/RelationTest.php
+++ b/test/RelationTest.php
@@ -179,7 +179,7 @@ class RelationTest extends DatabaseTestCase
     {
         $this->assert_sql_includes(
             'SELECT * FROM `books` WHERE name = ? ORDER BY name',
-            \test\models\Book::where('name = ?', 'The Art of Main Tanking')
+            test\models\Book::where('name = ?', 'The Art of Main Tanking')
                 ->order('name')->to_sql()
         );
     }

--- a/test/RelationshipTest.php
+++ b/test/RelationshipTest.php
@@ -303,7 +303,7 @@ class RelationshipTest extends DatabaseTestCase
 
     public function testHasAndBelongsToManyDoesNotEagerLoad()
     {
-        $this->expectException(\Exception::class);
+        $this->expectException(Exception::class);
         $hasAndBelongsToMany = new HasAndBelongsToMany(Book::class);
         $hasAndBelongsToMany->load_eagerly([], [], [], Table::load(Book::class));
     }
@@ -400,7 +400,7 @@ class RelationshipTest extends DatabaseTestCase
         try {
             $venue->events[0]->save();
             $this->fail('expected exception ActiveRecord\ReadonlyException');
-        } catch (ReadonlyException $e) {
+        } catch (ReadOnlyException $e) {
         }
 
         $venue->events[0]->description = 'new desc';
@@ -523,7 +523,7 @@ class RelationshipTest extends DatabaseTestCase
 
         $venue = Venue::find(2);
         $this->assertTrue(1 === count($venue->hosts));
-        $this->assert_sql_includes('events.title !=', ActiveRecord\Table::load(Host::class)->last_sql);
+        $this->assert_sql_includes('events.title !=', Table::load(Host::class)->last_sql);
     }
 
     public function testHasManyThroughUsingSource()
@@ -545,7 +545,7 @@ class RelationshipTest extends DatabaseTestCase
 
     public function testHasManyThroughWithInvalidClassName()
     {
-        $this->expectException(\ReflectionException::class);
+        $this->expectException(ReflectionException::class);
         Event::$belongs_to = [
             'host' => true
         ];
@@ -585,7 +585,7 @@ class RelationshipTest extends DatabaseTestCase
             $this->assertEquals($book->secondary_author_id, $author->parent_author_id);
         }
 
-        $this->assertTrue(false !== strpos(ActiveRecord\Table::load(Book::class)->last_sql, 'secondary_author_id'));
+        $this->assertTrue(false !== strpos(Table::load(Book::class)->last_sql, 'secondary_author_id'));
     }
 
     public function testHasOneBasic()
@@ -648,7 +648,7 @@ class RelationshipTest extends DatabaseTestCase
         try {
             $employee->position->save();
             $this->fail('expected exception ActiveRecord\ReadonlyException');
-        } catch (ReadonlyException $e) {
+        } catch (ReadOnlyException $e) {
         }
 
         $employee->position->title = 'new title';
@@ -681,7 +681,7 @@ class RelationshipTest extends DatabaseTestCase
 
         $book = Book::find(1);
         $this->assertEquals($book->secondary_author_id, $book->explicit_author->parent_author_id);
-        $this->assertTrue(false !== strpos(ActiveRecord\Table::load(Author::class)->last_sql, 'parent_author_id'));
+        $this->assertTrue(false !== strpos(Table::load(Author::class)->last_sql, 'parent_author_id'));
     }
 
     public function testDontAttemptToLoadIfAllForeignKeysAreNull()
@@ -727,7 +727,7 @@ class RelationshipTest extends DatabaseTestCase
         ];
         $venues = Venue::includes('events')->find([2, 6]);
 
-        $this->assert_sql_includes('WHERE (title = ?) AND (venue_id IN(?,?)) ORDER BY id asc', ActiveRecord\Table::load(Event::class)->last_sql);
+        $this->assert_sql_includes('WHERE (title = ?) AND (venue_id IN(?,?)) ORDER BY id asc', Table::load(Event::class)->last_sql);
         $this->assertEquals(1, count($venues[0]->events));
     }
 
@@ -750,7 +750,7 @@ class RelationshipTest extends DatabaseTestCase
     public function testEagerLoadingHasManyX()
     {
         $venues = Venue::includes('events')->find([2, 6]);
-        $this->assert_sql_includes('WHERE venue_id IN(?,?)', ActiveRecord\Table::load(Event::class)->last_sql);
+        $this->assert_sql_includes('WHERE venue_id IN(?,?)', Table::load(Event::class)->last_sql);
 
         foreach ($venues[0]->events as $event) {
             $this->assertEquals($event->venue_id, $venues[0]->id);
@@ -767,8 +767,8 @@ class RelationshipTest extends DatabaseTestCase
             $this->assertTrue(empty($v->events));
         }
 
-        $this->assert_sql_includes('WHERE id IN(?,?)', ActiveRecord\Table::load(Venue::class)->last_sql);
-        $this->assert_sql_includes('WHERE venue_id IN(?,?)', ActiveRecord\Table::load(Event::class)->last_sql);
+        $this->assert_sql_includes('WHERE id IN(?,?)', Table::load(Venue::class)->last_sql);
+        $this->assert_sql_includes('WHERE venue_id IN(?,?)', Table::load(Event::class)->last_sql);
     }
 
     public function testEagerLoadingHasManyArrayOfIncludes()
@@ -794,9 +794,9 @@ class RelationshipTest extends DatabaseTestCase
             $this->assertIsArray($authors[1]->$assoc);
         }
 
-        $this->assert_sql_includes('WHERE author_id IN(?,?)', ActiveRecord\Table::load(Author::class)->last_sql);
-        $this->assert_sql_includes('WHERE author_id IN(?,?)', ActiveRecord\Table::load(Book::class)->last_sql);
-        $this->assert_sql_includes('WHERE author_id IN(?,?)', ActiveRecord\Table::load(AwesomePerson::class)->last_sql);
+        $this->assert_sql_includes('WHERE author_id IN(?,?)', Table::load(Author::class)->last_sql);
+        $this->assert_sql_includes('WHERE author_id IN(?,?)', Table::load(Book::class)->last_sql);
+        $this->assert_sql_includes('WHERE author_id IN(?,?)', Table::load(AwesomePerson::class)->last_sql);
     }
 
     public function testEagerLoadingHasManyNested()
@@ -815,9 +815,9 @@ class RelationshipTest extends DatabaseTestCase
             }
         }
 
-        $this->assert_sql_includes('WHERE id IN(?,?)', ActiveRecord\Table::load(Venue::class)->last_sql);
-        $this->assert_sql_includes('WHERE venue_id IN(?,?)', ActiveRecord\Table::load(Event::class)->last_sql);
-        $this->assert_sql_includes('WHERE id IN(?,?,?)', ActiveRecord\Table::load(Host::class)->last_sql);
+        $this->assert_sql_includes('WHERE id IN(?,?)', Table::load(Venue::class)->last_sql);
+        $this->assert_sql_includes('WHERE venue_id IN(?,?)', Table::load(Event::class)->last_sql);
+        $this->assert_sql_includes('WHERE id IN(?,?,?)', Table::load(Host::class)->last_sql);
     }
 
     public function testEagerLoadingBelongsTo()
@@ -829,7 +829,7 @@ class RelationshipTest extends DatabaseTestCase
             $this->assertEquals($event->venue_id, $event->venue->id);
         }
 
-        $this->assert_sql_includes('WHERE id IN(?,?,?,?,?)', ActiveRecord\Table::load(Venue::class)->last_sql);
+        $this->assert_sql_includes('WHERE id IN(?,?,?,?,?)', Table::load(Venue::class)->last_sql);
     }
 
     public function testEagerLoadingBelongsToArrayOfIncludes()
@@ -841,9 +841,9 @@ class RelationshipTest extends DatabaseTestCase
             $this->assertEquals($event->host_id, $event->host->id);
         }
 
-        $this->assert_sql_includes('WHERE id IN(?,?,?,?,?)', ActiveRecord\Table::load(Event::class)->last_sql);
-        $this->assert_sql_includes('WHERE id IN(?,?,?,?,?)', ActiveRecord\Table::load(Host::class)->last_sql);
-        $this->assert_sql_includes('WHERE id IN(?,?,?,?,?)', ActiveRecord\Table::load(Venue::class)->last_sql);
+        $this->assert_sql_includes('WHERE id IN(?,?,?,?,?)', Table::load(Event::class)->last_sql);
+        $this->assert_sql_includes('WHERE id IN(?,?,?,?,?)', Table::load(Host::class)->last_sql);
+        $this->assert_sql_includes('WHERE id IN(?,?,?,?,?)', Table::load(Venue::class)->last_sql);
     }
 
     public function testEagerLoadingBelongsToNested()
@@ -866,9 +866,9 @@ class RelationshipTest extends DatabaseTestCase
             $this->assertEquals($book->author->author_id, $book->author->awesome_people[0]->author_id);
         }
 
-        $this->assert_sql_includes('WHERE book_id IN(?,?)', ActiveRecord\Table::load(Book::class)->last_sql);
-        $this->assert_sql_includes('WHERE author_id IN(?,?)', ActiveRecord\Table::load(Author::class)->last_sql);
-        $this->assert_sql_includes('WHERE author_id IN(?,?)', ActiveRecord\Table::load(AwesomePerson::class)->last_sql);
+        $this->assert_sql_includes('WHERE book_id IN(?,?)', Table::load(Book::class)->last_sql);
+        $this->assert_sql_includes('WHERE author_id IN(?,?)', Table::load(Author::class)->last_sql);
+        $this->assert_sql_includes('WHERE author_id IN(?,?)', Table::load(AwesomePerson::class)->last_sql);
     }
 
     public function testEagerLoadingBelongsToWithNoRelatedRows()
@@ -883,8 +883,8 @@ class RelationshipTest extends DatabaseTestCase
             $this->assertNull($e->venue);
         }
 
-        $this->assert_sql_includes('WHERE id IN(?,?)', ActiveRecord\Table::load(Event::class)->last_sql);
-        $this->assert_sql_includes('WHERE id IN(?,?)', ActiveRecord\Table::load(Venue::class)->last_sql);
+        $this->assert_sql_includes('WHERE id IN(?,?)', Table::load(Event::class)->last_sql);
+        $this->assert_sql_includes('WHERE id IN(?,?)', Table::load(Venue::class)->last_sql);
     }
 
     public function testEagerLoadingClonesRelatedObjects()
@@ -931,7 +931,7 @@ class RelationshipTest extends DatabaseTestCase
             ]
         ];
 
-        $c = ActiveRecord\Table::load(Book::class)->conn;
+        $c = Table::load(Book::class)->conn;
 
         $select = "books.*, authors.name as to_author_name, {$c->quote_name('from_')}.name as from_author_name, {$c->quote_name('another')}.name as another_author_name";
         $book = Book::joins(['to', 'from_', 'another'])

--- a/test/SerializationTest.php
+++ b/test/SerializationTest.php
@@ -100,7 +100,7 @@ class SerializationTest extends DatabaseTestCase
     {
         $now = new DateTime();
         $a = $this->_a(['only' => 'created_at'], new Author(['created_at' => $now]));
-        $this->assertEquals($now->format(\ActiveRecord\Serialize\Serialization::$DATETIME_FORMAT), $a['created_at']);
+        $this->assertEquals($now->format(ActiveRecord\Serialize\Serialization::$DATETIME_FORMAT), $a['created_at']);
     }
 
     public function testToJson()
@@ -200,7 +200,7 @@ class SerializationTest extends DatabaseTestCase
         $book = Book::find(1);
         $this->assertEquals('secondary_author_id,name',
             $book->to_csv(['only'=>['secondary_author_id', 'name'],
-                                'only_header'=>true])
+                'only_header'=>true])
         );
     }
 

--- a/test/SqliteAdapterTest.php
+++ b/test/SqliteAdapterTest.php
@@ -7,7 +7,7 @@ use ActiveRecord\Exception\ConnectionException;
 
 class SqliteAdapterTest extends AdapterTestCase
 {
-    public function setUp(string $connection_name=null): void
+    public function setUp(?string $connection_name=null): void
     {
         parent::setUp('sqlite');
     }

--- a/test/ValidationsTest.php
+++ b/test/ValidationsTest.php
@@ -22,7 +22,7 @@ class BookValidations extends ActiveRecord\Model
 
 class ValidationsTest extends DatabaseTestCase
 {
-    public function setUp(string $connection_name=null): void
+    public function setUp(?string $connection_name=null): void
     {
         parent::setUp($connection_name);
 

--- a/test/helpers/AdapterTestCase.php
+++ b/test/helpers/AdapterTestCase.php
@@ -10,7 +10,7 @@ abstract class AdapterTestCase extends DatabaseTestCase
 {
     public const InvalidDb = '__1337__invalid_db__';
 
-    public function setUp(string $connection_name=null): void
+    public function setUp(?string $connection_name=null): void
     {
         if (($connection_name && !in_array($connection_name, PDO::getAvailableDrivers()))
             || 'skip' == ActiveRecord\Config::instance()->get_connection($connection_name)) {

--- a/test/helpers/DatabaseTestCase.php
+++ b/test/helpers/DatabaseTestCase.php
@@ -17,7 +17,7 @@ abstract class DatabaseTestCase extends TestCase
     public static $log = false;
     public static $db;
 
-    public function setUp(string $connection_name=null): void
+    public function setUp(?string $connection_name=null): void
     {
         ActiveRecord\Table::clear_cache();
         Cache::flush();
@@ -38,7 +38,7 @@ abstract class DatabaseTestCase extends TestCase
         }
 
         try {
-            ActiveRecord\ConnectionManager::get_connection($connection_name);
+            ConnectionManager::get_connection($connection_name);
         } catch (Exception $e) {
             $this->markTestSkipped($connection_name . ' failed to connect. ' . $e->getMessage());
         }

--- a/test/helpers/config.php
+++ b/test/helpers/config.php
@@ -51,9 +51,9 @@ ActiveRecord\Config::initialize(function ($cfg) {
 
     if (class_exists('Monolog\Logger')) { // Monolog installed
         $log = new Monolog\Logger('arlog');
-        $log->pushHandler(new \Monolog\Handler\StreamHandler(
+        $log->pushHandler(new Monolog\Handler\StreamHandler(
             dirname(__FILE__) . '/../log/query.log',
-            \Monolog\Level::Warning)
+            Monolog\Level::Warning)
         );
 
         $cfg->set_logging(true);

--- a/test/phpstan/ModelDynamicFindBy.php
+++ b/test/phpstan/ModelDynamicFindBy.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is not something we need to execute in tests. It's included
  * only as a means to test and aid in the development of dynamic PHPStan

--- a/test/phpstan/ModelFindByDynamicReturn.php
+++ b/test/phpstan/ModelFindByDynamicReturn.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is not something we need to execute in tests. It's included
  * only as a means to test and aid in the development of dynamic PHPStan

--- a/test/phpstan/ModelToRelation.php
+++ b/test/phpstan/ModelToRelation.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is not something we need to execute in tests. It's included
  * only as a means to test and aid in the development of dynamic PHPStan

--- a/test/phpstan/RelationFindByDynamicReturn.php
+++ b/test/phpstan/RelationFindByDynamicReturn.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is not something we need to execute in tests. It's included
  * only as a means to test and aid in the development of dynamic PHPStan

--- a/test/phpstan/RelationFindDynamicReturn.php
+++ b/test/phpstan/RelationFindDynamicReturn.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is not something we need to execute in tests. It's included
  * only as a means to test and aid in the development of dynamic PHPStan

--- a/test/phpstan/RelationFirstDynamicReturn.php
+++ b/test/phpstan/RelationFirstDynamicReturn.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is not something we need to execute in tests. It's included
  * only as a means to test and aid in the development of dynamic PHPStan

--- a/test/phpstan/RelationLastDynamicReturn.php
+++ b/test/phpstan/RelationLastDynamicReturn.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is not something we need to execute in tests. It's included
  * only as a means to test and aid in the development of dynamic PHPStan

--- a/test/phpstan/RelationTakeDynamicReturn.php
+++ b/test/phpstan/RelationTakeDynamicReturn.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is not something we need to execute in tests. It's included
  * only as a means to test and aid in the development of dynamic PHPStan

--- a/test/phpstan/RelationToModel.php
+++ b/test/phpstan/RelationToModel.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is not something we need to execute in tests. It's included
  * only as a means to confirm that Relation methods are set up with generics
@@ -11,12 +12,12 @@ class RelationToModel
 {
     protected Book $book;
 
-    public function bookFromFirst(): Book|null
+    public function bookFromFirst(): ?Book
     {
         return Book::all()->first();
     }
 
-    public function bookFromLast(): Book|null
+    public function bookFromLast(): ?Book
     {
         return Book::all()->last();
     }
@@ -45,7 +46,7 @@ class RelationToModel
         return Book::all()->to_a();
     }
 
-    public function bookFromTake(): Book|null
+    public function bookFromTake(): ?Book
     {
         return Book::all()->take();
     }


### PR DESCRIPTION
I simply ran vendor\bin\php-cs-fixer fix

This automatically will convert to PHP 8.4 to fix this error (and all the others):

Deprecated: ActiveRecord\Table::insert(): Implicitly marking parameter $sequence_name as nullable is deprecated, the explicit nullable type must be used instead in vendor\php-patterns\activerecord\lib\Table.php on line 411

Please merge.  Thanks